### PR TITLE
Stop byte-compiling modeline format functions

### DIFF
--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -286,10 +286,7 @@ active.")
       (concat "Modeline:\n"
               (format "  %s\n  %s"
                       (prin1-to-string lhs)
-                      (prin1-to-string rhs))))
-    (unless (bound-and-true-p byte-compile-current-file)
-      (let (byte-compile-warnings)
-        (byte-compile sym)))))
+                      (prin1-to-string rhs))))))
 
 (defun doom-modeline (key)
   "Return a mode-line configuration associated with KEY (a symbol).


### PR DESCRIPTION
I actually have no idea why this would happen, but if the file is not byte-compiled beforehand, there will be quite a few warnings of `Unused lexical var` each time when the `doom-modeline-def-modeline` is called.

If users install this package through `package.el`, this will not cause any problem. However, if users install this package manually, this will be very annoying.

Note that the similar thing has been done in Doom Emacs in this commit: https://github.com/hlissner/doom-emacs/commit/70e0280db39b1ee8f2f4184b21c03260210392f4.

By the way, thank you for bringing and maintaining this awesome package.