### PR TITLE
Fix an issue that may cause rhs disappeared

### DIFF
--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -276,7 +276,7 @@ active.")
         (rhs-forms (doom-modeline--prepare-segments rhs)))
     (defalias sym
       (lambda ()
-        (let ((rhs-str (format-mode-line rhs-forms)))
+        (let ((rhs-str (format-mode-line (cons "" rhs-forms))))
           (list lhs-forms
                 (propertize
                  " " 'display


### PR DESCRIPTION
According to the [documentation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Mode-Line-Data.html#Mode-Line-Data), a list of which the first element is a symbol is treated as a conditional. So if the first element of `rhs` happens to be a variable, then the whole `rhs-form` will not be rendered correctly by `format-mode-line`.

Thanks!