### PR TITLE
Don't try to call anzu functions if anzu isn't installed

### DIFF
--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -379,9 +379,10 @@ active.")
 ;;                             anzu--last-isearch-string anzu--overflow-p))
 
 ;; Ensure anzu state is cleared when searches & iedit are done
-(add-hook 'isearch-mode-end-hook #'anzu--reset-status t)
-(add-hook 'iedit-mode-end-hook #'anzu--reset-status)
-(advice-add #'evil-force-normal-state :after #'anzu--reset-status)
+(with-eval-after-load 'anzu
+  (add-hook 'isearch-mode-end-hook #'anzu--reset-status t)
+  (add-hook 'iedit-mode-end-hook #'anzu--reset-status)
+  (advice-add #'evil-force-normal-state :after #'anzu--reset-status))
 
 ;; Keep `doom-modeline-current-window' up-to-date
 (defvar doom-modeline-current-window (frame-selected-window))


### PR DESCRIPTION
I don't use anzu, I occasionally get this error "Symbol’s function definition is void: anzu--reset-status" coming from doom-modeline. This PR is an attempt to fix this.