### PR TITLE
Fix: require subr-x (needed for when-let)

### DIFF
--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -61,6 +61,7 @@
 (require 'eldoc-eval)
 (require 'projectile)
 (require 'shrink-path)
+(require 'subr-x)
 
 ;;
 ;; Variables


### PR DESCRIPTION
Its absence results in a compile error when using borg-build:

    In toplevel form:
    doom-modeline.el:314:1:Warning: Unused lexical argument ‘key’

    In doom-modeline-set-modeline:
    doom-modeline.el:314:50:Warning: ‘(modeline (doom-modeline key))’ is a
        malformed function
    doom-modeline.el:322:22:Warning: reference to free variable ‘modeline’

    In doom-modeline-set-selected-window:
    doom-modeline.el:390:49:Warning: ‘(win (frame-selected-window))’ is a
        malformed function
    doom-modeline.el:393:41:Warning: reference to free variable ‘win’

    In end of data:
    doom-modeline.el:1249:1:Warning: the function ‘when-let’ is not known to be
        defined.

Which ultimately results in an error disrupting proper startup:

    Invalid function: (modeline (doom-modeline key))