### PR TITLE
Fix python-mode when executable is nil

### DIFF
--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -1237,7 +1237,7 @@ See `mode-line-percent-position'.")
 ;; Versions, support Python, Ruby, Perl and Golang, etc.
 (add-hook 'python-mode-hook
           (lambda ()
-            (when (and (executable-find doom-modeline-python-executable) (executable-find "cut") (executable-find "sed"))
+            (when (and doom-modeline-python-executable (executable-find doom-modeline-python-executable) (executable-find "cut") (executable-find "sed"))
               (setq doom-modeline-env-command (concat doom-modeline-python-executable " --version 2>&1 | cut -d' ' -f2 | sed -n '1p'")))))
 (add-hook 'ruby-mode-hook
           (lambda ()


### PR DESCRIPTION
Since executable-find cannot handle a nil argument then doom-modeline-python-executable should not be passed if it is set to nil.