### PR TITLE
Fix calling `projectile-project-root'.

### DIFF
--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -374,7 +374,8 @@ If DEFAULT is non-nil, set the default mode-line for all buffers."
       (setq doom-modeline-project-root
             (file-local-name
              (or
-              (when (featurep 'projectile) (projectile-project-root))
+              (when (featurep 'projectile)
+                (ignore-errors (projectile-project-root)))
               (when (featurep 'project)
                 (when-let ((project (project-current)))
                   (expand-file-name (car (project-roots project)))))


### PR DESCRIPTION
Depending on configuration, `projectile-project-root' raises an error if there
is no project available. This behaviour almost renders Emacs unusable outside
of projects as `doom-modeline-project-root' gets called upon every redisplay of
the modeline, which then causes the error.

This fix just ignores errors thrown by `projectile-project-root' and returns
`nil' instead, which is what we expect anyway.