### PR TITLE
Update file state icon after widening

### DIFF
--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -767,6 +767,7 @@ buffer where knowing the current project directory is important."
 (advice-add #'undo :after #'doom-modeline-update-buffer-file-state-icon)
 (advice-add #'undo-tree-undo :after #'doom-modeline-update-buffer-file-state-icon)
 (advice-add #'narrow-to-region :after #'doom-modeline-update-buffer-file-state-icon)
+(advice-add #'widen :after #'doom-modeline-update-buffer-file-state-icon)
 
 (defvar-local doom-modeline--buffer-file-name nil)
 (defun doom-modeline-update-buffer-file-name (&rest _)


### PR DESCRIPTION
This PR solves this issue: `widen` doesn't remove the "narrowed" file state icon.

To reproduce the issue:
- M-x narrow-to-defun -- the "narrowed" file state icon is displayed in the modeline
- M-x widen -- the "narrowed" file state icon is still displayed in the modeline, but I expect it not to be there because the buffer is not narrowed anymore