### PR TITLE
add python-venv state

### DIFF
--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -940,7 +940,7 @@ mouse-3: Toggle minor modes"
 
 (doom-modeline-def-segment python-venv
   "The current python virtual environment state."
-  (when (boundp 'python-shell-virtualenv-root)
+  (when (eq major-mode 'python-mode)
     (if (eq python-shell-virtualenv-root nil)
         ""
       (propertize

--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -946,8 +946,8 @@ mouse-3: Toggle minor modes"
       (propertize
        (let ((base-dir-name (file-name-nondirectory (substring python-shell-virtualenv-root 0 -1))))
          (if (< 13 (length base-dir-name))
-             (format " %s..." (substring base-dir-name 0 10))
-           (format " %s" base-dir-name)))
+             (format " (%s...)" (substring base-dir-name 0 10))
+           (format " (%s)" base-dir-name)))
        'face (if (doom-modeline--active) 'doom-modeline-buffer-major-mode)))))
 
 

--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -935,6 +935,23 @@ mouse-3: Toggle minor modes"
 
 
 ;;
+;; python-venv
+;;
+
+(doom-modeline-def-segment python-venv
+  "The current python virtual environment state."
+  (when (boundp 'python-shell-virtualenv-root)
+    (if (eq python-shell-virtualenv-root nil)
+        ""
+      (propertize
+       (let ((base-dir-name (file-name-nondirectory (substring python-shell-virtualenv-root 0 -1))))
+         (if (< 13 (length base-dir-name))
+             (format " %s..." (substring base-dir-name 0 10))
+           (format " %s" base-dir-name)))
+       'face (if (doom-modeline--active) 'doom-modeline-buffer-major-mode)))))
+
+
+;;
 ;; process
 ;;
 
@@ -1637,7 +1654,7 @@ mouse-1: Toggle Debug on Quit"
 
 (doom-modeline-def-modeline 'main
   '(bar workspace-number window-number evil-state god-state ryo-modal xah-fly-keys matches " " buffer-info remote-host buffer-position " " selection-info)
-  '(misc-info persp-name lsp github debug minor-modes input-method buffer-encoding major-mode process vcs flycheck))
+  '(misc-info persp-name lsp github debug minor-modes input-method buffer-encoding major-mode python-venv process vcs flycheck))
 
 (doom-modeline-def-modeline 'minimal
   '(bar matches " " buffer-info)


### PR DESCRIPTION
add python-venv state using python-shell-virtualenv-root variable, Any virtual environment manager,e.g. pipenv.el, pyvenv.el, conda.el, which changes this variable can trigger the python-venv state

### venv activated in non-pipenv project:
![image](https://user-images.githubusercontent.com/28672146/50413219-9317f880-0848-11e9-8c6a-7fb8399c9444.png)

### venv deactivated in non-pipenv project:
![image](https://user-images.githubusercontent.com/28672146/50413212-7ed3fb80-0848-11e9-8195-6b3f533afe00.png)

### venv activated in pipenv project:
![image](https://user-images.githubusercontent.com/28672146/50413169-3a486000-0848-11e9-9c98-415dc2f5700a.png)

### venv deactivated in pipenv project:
![image](https://user-images.githubusercontent.com/28672146/50413159-21d84580-0848-11e9-8bbe-82bdafd2640c.png)

In these demos, I used pyvenv.el instead of pipenv.el to manage the virtual environment

