### PR TITLE
Remove unnecessary use-package :defer

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ In `init.el`,
 ``` emacs-lisp
 (use-package doom-modeline
       :ensure t
-      :defer t
       :hook (after-init . doom-modeline-init))
 ```
 


### PR DESCRIPTION
According to use-package manual
> If you aren't using :commands, :bind, :bind*, :bind-keymap, :bind-keymap*, :mode, :interpreter, or :hook (all of which imply :defer ...