### PR TITLE
Make programming environment version parsing asynchronous

### DIFF
--- a/doom-version-parser.el
+++ b/doom-version-parser.el
@@ -1,0 +1,86 @@
+;;; doom-version-parser.el --- A version parser for doom-modeline -*- lexical-binding: t -*-
+
+;; Copyright (C) 2019 Justin Barclay
+
+;; Version: 1.4.5
+;;
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 2, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program; see the file COPYING.  If not, write to
+;; the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+;; Floor, Boston, MA 02110-1301, USA.
+;;
+
+(require 'subr-x)
+
+(defun doom-version-parser--ruby (line)
+  (car (split-string
+        (cadr
+         (split-string line))
+        "p")))
+
+(defun doom-version-parser--elixir (line)
+  (cadr
+   (split-string line)))
+
+(defun doom-version-parser--rustc (line)
+  (car
+   (split-string
+    (cadr
+     (split-string line))
+    "-")))
+
+(defun doom-version-parser--go (line)
+  (cadr
+   (split-string
+    (cadr
+     (cdr
+      (split-string
+       line)))
+    "go")))
+
+(defun doom-version-parser--perl (line)
+  (cadr
+   (split-string
+    (car
+     (split-string
+      (cadr
+       (split-string line "("))
+      ")"))
+    "v")))
+
+(defun doom-version-parser--python (line)
+  (cadr
+   (split-string line)))
+
+(defun doom-version-parser--get (prog args callback)
+  "Starts a sub process using prog and applies the args to the sub process.
+   Once it recieves information from STDOUT, it closes off the subprocess and
+   passes on the information into the callback.
+   Ex: (doom-version-parser--get \"ruby\" '(\"version\") (lambda (line) (message (doom-modeline-parser--ruby)))"
+  (let ((proc (apply 'start-process
+		     (append ;; Flaten process-args into a single list so we can handle variadic length args
+                      (list "doom-modeline-prog" "doom-modeline-prog" prog)
+                      args)))
+        (parser callback))
+    (set-process-filter proc (lambda (proc1 line)
+			       (defvar old-buffer-query-functions kill-buffer-query-functions) ;; Store old query function
+			       (setq kill-buffer-query-functions nil) ;; No need to query user when we kill this buffer and process
+			       (kill-process proc1) ;; Clean up after ourselves
+			       (kill-buffer "doom-modeline-prog")
+			       (setq kill-buffer-query-functions old-buffer-query-functions) ;; let's restore everthing
+			       (funcall parser line)))
+    nil))
+
+(provide 'doom-version-parser)
+
+;;; doom-version-parser.el ends here

--- a/test/doom-version-parser-test.el
+++ b/test/doom-version-parser-test.el
@@ -1,0 +1,71 @@
+;;; doom-version-parser-test.el --- Unit tests for doom-version-parser -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2019 Justin Barclay
+
+;; This file is not part of GNU Emacs.
+
+;;
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 2, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program; see the file COPYING.  If not, write to
+;; the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+;; Floor, Boston, MA 02110-1301, USA.
+;;
+
+;;; Commentary:
+;;
+;;  Unit tests for doom-version-parser
+;;
+
+;;; Code:
+(ert-deftest doom-version-parser--ruby/parse-ruby-version-string ()
+  (should
+   (string= (doom-version-parser--ruby "ruby 2.3.3p222 (2016-11-21 revision 56859) [x86_64-darwin16]")
+            "2.3.3")))
+
+(ert-deftest doom-version-parser--elixir/parse-elixr-version-string ()
+  (should
+   (string= (doom-version-parser--elixir "IEx 1.7.4 (compiled with Erlang/OTP 21)")
+            "1.7.4")))
+
+(ert-deftest doom-version-parser--rustc/parse-rustc-version-string ()
+  (should
+   (string= (doom-version-parser--rustc "rustc 1.32.0-nightly (14997d56a 2018-12-05)")
+            "1.32.0")))
+
+(ert-deftest doom-version-parser--go/parse-go-version-string ()
+  (should
+   (string= (doom-version-parser--go "go version go1.11.4 darwin/amd64")
+            "1.11.4")))
+
+(ert-deftest doom-version-parser--perl/parse-perl-version-string ()
+  (should
+   (string= (doom-version-parser--perl
+             "This is perl 5, version 18, subversion 2 (v5.18.2) built for darwin-thread-multi-2level
+(with 2 registered patches, see perl -V for more detail)
+
+Copyright 1987-2013, Larry Wall
+
+Perl may be copied only under the terms of either the Artistic License or the
+GNU General Public License, which may be found in the Perl 5 source kit.
+
+Complete documentation for Perl, including FAQ lists, should be found on
+this system using \"man perl\" or \"perldoc perl\".  If you have access to the
+Internet, point your browser at http://www.perl.org/, the Perl Home Page.")
+            "5.18.2")))
+
+(ert-deftest doom-version-parser--python/parse-python-version-string ()
+  (should
+   (string= (doom-version-parser--python "Python 2.7.15")
+            "2.7.15")))
+
+;;; doom-version-parser-test.el ends here


### PR DESCRIPTION
This PR is meant to address issue #90.

In this PR, I changed the `doom-modeline-env-update` command to use a new non-blocking function, `doom-version-parser--get`. I also added two more local variables to doom-modeline. One is `doom-modeline-env-command-args` which is a list of strings needed to get a program to print out version information. The other is `doom-modeline-env-parser` which is a elisp function that is used to parse the resultant string and return the version number of the program. Because of these changes required a significant rewriting of the mode hooks for modes that tracked version information.