### PR TITLE
mu4e: add new segment that shows unread emails

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -119,6 +119,9 @@ The icons may not be showed correctly in terminal and on Windows.")
 (defvar doom-modeline-version t
   "Whether display environment version or not.")
 
+(defvar doom-modeline-mu4e t
+  "Whether display mu4e notifications or not. Requires `mu4e-alert' package.")
+
 
 ;;
 ;; Custom faces

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -69,6 +69,7 @@
 (defvar text-scale-mode-amount)
 (defvar winum-auto-setup-mode-line)
 (defvar xah-fly-insert-state-q)
+(defvar mu4e-alert-mode-line)
 
 (declare-function anzu--reset-status 'anzu)
 (declare-function anzu--where-is-here 'anzu)
@@ -1492,6 +1493,32 @@ mouse-1: Toggle Debug on Quit"
     (format "  P%d/%d "
             (eval `(pdf-view-current-page))
             (pdf-cache-number-of-pages))))
+
+
+;;
+;; mu4e-alert notifications
+;;
+
+(defun doom-modeline-mu4e-formatter (mail-count)
+  "Doom mode-line's `mu4e-alert' formatter.
+MAIL-COUNT is the count of mails for which the string is to displayed"
+  (when (not (zerop mail-count))
+    (concat
+     (propertize
+      (format "%s" mail-count)
+      'display '(raise 0.09)
+      'face '(:height 0.85)
+      'help-echo (if (= mail-count 1)
+                     "You have an unread email"
+                   (format "You have %s unread emails" mail-count)))
+
+     ;; add a little space for padding
+     (propertize " " 'display '(space-width 0.6)))))
+
+(doom-modeline-def-segment mu4e
+  (when doom-modeline-mu4e
+    ;; this is the result of the mu4e formatter
+    mu4e-alert-mode-line))
 
 (provide 'doom-modeline-segments)
 

--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -83,7 +83,7 @@
 
 (doom-modeline-def-modeline 'main
   '(bar workspace-number window-number evil-state god-state ryo-modal xah-fly-keys matches buffer-info remote-host buffer-position parrot selection-info)
-  '(misc-info persp-name lsp github debug minor-modes input-method buffer-encoding major-mode process vcs checker))
+  '(misc-info persp-name lsp mu4e github debug minor-modes input-method buffer-encoding major-mode process vcs checker))
 
 (doom-modeline-def-modeline 'minimal
   '(bar matches " " buffer-info)
@@ -95,7 +95,7 @@
 
 (doom-modeline-def-modeline 'project
   '(bar " " buffer-default-directory)
-  '(misc-info github debug " " major-mode " "))
+  '(misc-info mu4e github debug " " major-mode " "))
 
 (doom-modeline-def-modeline 'media
   '(bar window-number buffer-size buffer-info)
@@ -147,12 +147,23 @@ If DEFAULT is non-nil, set the default mode-line for all buffers."
   "Set pdf mode-line."
   (doom-modeline-set-modeline 'pdf))
 
+;;;###autoload
+(defun doom-modeline--remove-mu4e-alert-string ()
+  "Remove the default `mu4e-alert' string.
+
+The string will conflict with our custom segment."
+  (setq global-mode-string (delete '(:eval mu4e-alert-mode-line)
+                                   global-mode-string)))
+
 
 ;;
 ;; Mode
 ;;
 
 (defvar doom-modeline--default-mode-line mode-line-format)
+(defvar mu4e-alert-modeline-formatter)
+(declare-function mu4e-alert-default-mode-line-formatter 'mu4e-alert)
+(declare-function mu4e-alert-enable-mode-line-display 'mu4e-alert)
 
 ;;;###autoload
 (define-minor-mode doom-modeline-mode
@@ -174,7 +185,10 @@ If DEFAULT is non-nil, set the default mode-line for all buffers."
         (add-hook 'dashboard-mode-hook #'doom-modeline-set-project-modeline)
         (add-hook 'image-mode-hook #'doom-modeline-set-media-modeline)
         (add-hook 'circe-mode-hook #'doom-modeline-set-special-modeline)
-        (add-hook 'pdf-tools-enabled-hook #'doom-modeline-set-pdf-modeline))
+        (add-hook 'pdf-tools-enabled-hook #'doom-modeline-set-pdf-modeline)
+        (setq mu4e-alert-modeline-formatter #'doom-modeline-mu4e-formatter)
+        (advice-add #'mu4e-alert-enable-mode-line-display
+                      :after #'doom-modeline--remove-mu4e-alert-string))
     (progn
       ;; Restore mode-line
       (setq-default mode-line-format doom-modeline--default-mode-line)
@@ -182,7 +196,12 @@ If DEFAULT is non-nil, set the default mode-line for all buffers."
       (remove-hook 'dashboard-mode-hook #'doom-modeline-set-project-modeline)
       (remove-hook 'image-mode-hook #'doom-modeline-set-media-modeline)
       (remove-hook 'circe-mode-hook #'doom-modeline-set-special-modeline)
-      (remove-hook 'pdf-tools-enabled-hook #'doom-modeline-set-pdf-modeline))))
+      (remove-hook 'pdf-tools-enabled-hook #'doom-modeline-set-pdf-modeline)
+      ;; no harm in always restoring the defaults
+      (setq mu4e-alert-modeline-formatter
+            #'mu4e-alert-default-mode-line-formatter)
+      (advice-remove #'mu4e-alert-enable-mode-line-display
+                     #'doom-modeline--remove-mu4e-alert-string))))
 
 (provide 'doom-modeline)
 


### PR DESCRIPTION
This is a new segment for `mu4e-alert' that shows unread emails in the modeline. For now, we enable it where github notifications are enabled and make it a simple number.

When experimenting with adding an email icon, the modeline seemed a bit too crowed so there is no icon for this number. We can perhaps add a flag later to toggle that. Alternatively, we could expose more options for the `doom-modeline-mu4e-formatter' that could tweak the number and the icon.