### PR TITLE
Initialize mu4e-alert-modeline-formatter

### DIFF
--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -155,7 +155,7 @@ If DEFAULT is non-nil, set the default mode-line for all buffers."
 
 (defvar doom-modeline--default-mode-line mode-line-format)
 
-(defvar mu4e-alert-modeline-formatter)
+(defvar mu4e-alert-modeline-formatter nil)
 (defvar doom-modeline--mu4e-alert-modeline-formatter mu4e-alert-modeline-formatter)
 
 ;;;###autoload


### PR DESCRIPTION
This is required for those of us not using mu4e, otherwise, you get a void variable error.

This may not be the right way to do this, but without this, I cannot load doom-modeline.