### PR TITLE
Hide checker segment when disabled/empty

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -831,29 +831,31 @@ icons."
                     `(,doom-modeline--flymake-icon . ,doom-modeline--flymake-text))
                    ((bound-and-true-p flycheck-mode)
                     `(,doom-modeline--flycheck-icon . ,doom-modeline--flycheck-text)))))
-    (let ((icon (car seg))
-          (text (cdr seg)))
-      (concat
-       (propertize (if vc-mode " " "  ")
-                   'face (if active 'mode-line 'mode-line-inactive))
-       (if active
-           (concat icon
-                   (when (and icon text) doom-modeline-vspc)
-                   text)
-         (concat
-          (when icon
-            (propertize icon
-                        'face
-                        (if doom-modeline-icon
-                            `(:height
-                              ,(doom-modeline-icon-height 1.3)
-                              :family
-                              ,(all-the-icons-icon-family icon)
-                              :inherit mode-line-inactive)
-                          'mode-line-inactive)))
-          (when (and icon text) doom-modeline-inactive-vspc)
-          (when text (propertize text 'face 'mode-line-inactive))))
-       (propertize "  " 'face (if active 'mode-line 'mode-line-inactive))))))
+    (if seg
+        (let ((icon (car seg))
+              (text (cdr seg)))
+          (concat
+           (propertize (if vc-mode " " "  ")
+                       'face (if active 'mode-line 'mode-line-inactive))
+           (if active
+               (concat icon
+                       (when (and icon text) doom-modeline-vspc)
+                       text)
+             (concat
+              (when icon
+                (propertize icon
+                            'face
+                            (if doom-modeline-icon
+                                `(:height
+                                  ,(doom-modeline-icon-height 1.3)
+                                  :family
+                                  ,(all-the-icons-icon-family icon)
+                                  :inherit mode-line-inactive)
+                              'mode-line-inactive)))
+              (when (and icon text) doom-modeline-inactive-vspc)
+              (when text (propertize text 'face 'mode-line-inactive))))
+           (propertize "  " 'face (if active 'mode-line 'mode-line-inactive))))
+      "")))
 
 
 ;;


### PR DESCRIPTION
I've moved the checker segment to a different location. In buffers where `flycheck-mode` and `flymake-mode` are disabled (or have no checkers), a large gap is left behind.

![image](https://user-images.githubusercontent.com/510883/53594807-a9ed0b00-3b69-11e9-8e44-71b9dca9a403.png)

This PR fixes this.