### PR TITLE
Fix matches segment mirroring across all buffers

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -933,7 +933,12 @@ lines are selected, or the NxM dimensions of a block selection."
 (with-eval-after-load 'anzu
   (add-hook 'isearch-mode-end-hook #'anzu--reset-status t)
   (add-hook 'iedit-mode-end-hook #'anzu--reset-status)
-  (advice-add #'evil-force-normal-state :after #'anzu--reset-status))
+  (advice-add #'evil-force-normal-state :after #'anzu--reset-status)
+  ;; Fix matches segment mirroring across all buffers
+  (mapc #'make-variable-buffer-local
+        '(anzu--total-matched anzu--current-position anzu--state
+          anzu--cached-count anzu--cached-positions anzu--last-command
+          anzu--last-isearch-string anzu--overflow-p)))
 
 (defsubst doom-modeline--anzu ()
   "Show the match index and total number thereof.


### PR DESCRIPTION
A search in one buffer is displayed as matches across all buffer modelines:

![image](https://user-images.githubusercontent.com/510883/53595132-72329300-3b6a-11e9-8bbd-d139e88d777f.png)

This PR ensures anzu state is made buffer-local:

![image](https://user-images.githubusercontent.com/510883/53595503-7612e500-3b6b-11e9-9a30-687ed43d0441.png)
