### PR TITLE
Revert "Fix matches segment mirroring across all buffers"

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -935,12 +935,7 @@ lines are selected, or the NxM dimensions of a block selection."
 (with-eval-after-load 'anzu
   (add-hook 'isearch-mode-end-hook #'anzu--reset-status t)
   (add-hook 'iedit-mode-end-hook #'anzu--reset-status)
-  (advice-add #'evil-force-normal-state :after #'anzu--reset-status)
-  ;; Fix matches segment mirroring across all buffers
-  (mapc #'make-variable-buffer-local
-        '(anzu--total-matched anzu--current-position anzu--state
-          anzu--cached-count anzu--cached-positions anzu--last-command
-          anzu--last-isearch-string anzu--overflow-p)))
+  (advice-add #'evil-force-normal-state :after #'anzu--reset-status))
 
 (defsubst doom-modeline--anzu ()
   "Show the match index and total number thereof.


### PR DESCRIPTION
Reverts seagle0128/doom-modeline#125