### PR TITLE
Prevent anzu from injecting itself into modeline

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -931,6 +931,7 @@ lines are selected, or the NxM dimensions of a block selection."
 
 (advice-add #'anzu--where-is-here :override #'doom-modeline-fix-anzu-count)
 
+(setq anzu-cons-mode-line-p nil) ; manage modeline segment ourselves
 ;; Ensure anzu state is cleared when searches & iedit are done
 (with-eval-after-load 'anzu
   (add-hook 'isearch-mode-end-hook #'anzu--reset-status t)
@@ -941,7 +942,6 @@ lines are selected, or the NxM dimensions of a block selection."
   "Show the match index and total number thereof.
 Requires `anzu', also `evil-anzu' if using `evil-mode' for compatibility with
 `evil-search'."
-  (setq anzu-cons-mode-line-p nil)
   (when (and (bound-and-true-p anzu--state)
              (not (bound-and-true-p iedit-mode)))
     (propertize


### PR DESCRIPTION
If we wait to unset `anzu-cons-mode-line-p` until the first time the anzu sub-segment runs, then we create an opportunity for anzu to inject its own indicator into the modeline.

For example, in Doom, the dashboard is the first buffer you see. It displays the project modeline which has no matches segment. That means `anzu-cons-mode-line-p` won't be unset until I open another buffer with a modeline that possesses the segment. If I conduct a search in the dashboard before doing this...

![image](https://user-images.githubusercontent.com/510883/53595996-b45cd400-3b6c-11e9-8b41-815dfc4e84a4.png)

It's an obscure race/edge case, but I think it's best we tell anzu not to do this as soon as possible.