### PR TITLE
Highlight project-root for relative-from-project style

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -581,7 +581,7 @@ directory too."
        (`relative-to-project
         (doom-modeline--buffer-file-name-relative buffer-file-name buffer-file-truename))
        (`relative-from-project
-        (doom-modeline--buffer-file-name-relative buffer-file-name buffer-file-truename 'include-project))
+        (doom-modeline--buffer-file-name buffer-file-name buffer-file-truename nil nil 'hide))
        (style
         (propertize
          (pcase style


### PR DESCRIPTION
The `doom-modeline--buffer-file-name-relative` routine treats `project-root` as part of `relative-path`, so it doesn't get the proper face.  The `doom-modeline--buffer-file-name` routine already supports this style with the appropriate arguments, so we use that instead.