### PR TITLE
Use buffer-list-update-hook instead of advising select-window.

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -386,8 +386,8 @@ If DEFAULT is non-nil, set the default mode-line for all buffers."
   (force-mode-line-update))
 
 (add-hook 'window-configuration-change-hook #'doom-modeline-set-selected-window)
+(add-hook 'buffer-list-update-hook #'doom-modeline-set-selected-window)
 (advice-add #'handle-switch-frame :after #'doom-modeline-set-selected-window)
-(advice-add #'select-window :after #'doom-modeline-set-selected-window)
 (advice-add #'make-frame :after #'doom-modeline-set-selected-window)
 (advice-add #'delete-frame :after #'doom-modeline-set-selected-window)
 (with-no-warnings


### PR DESCRIPTION
Per the official docs of select-window if you want to call a function every time a window is selected you should use buffer-list-update-hook. It automatically does The Right Thing and gets called only when necessary.

The correction isn't theoretical either, advising select-window can lead to nasty feedback loops as in Alexander-Miller/treemacs#369.

Btw some of the other parts of advice in that sections could be replaced with after-make-frame-functions and delete-frame-functions.