### PR TITLE
Show number of multiple cursors correctly

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1052,7 +1052,7 @@ Requires `anzu', also `evil-anzu' if using `evil-mode' for compatibility with
   "Show the number of multiple cursors."
   (cl-destructuring-bind (count . face)
       (cond ((bound-and-true-p multiple-cursors-mode)
-             (cons (eval (cadadr mc/mode-line))
+             (cons (mc/num-cursors)
                    (if (doom-modeline--active)
                        'mode-line-inactive
                      'doom-modeline-eldoc-bar)))


### PR DESCRIPTION
Using `(mc/num-cursors)` instead of relying on what the modeline of multiple-cursors is.

Before this change nothing was shown in the "matches" section of the modeline.