### PR TITLE
Various fixes

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -516,6 +516,9 @@ Given ~/Projects/FOSS/emacs/lisp/comint.el
   "Whether is an active window."
   (eq (selected-window) doom-modeline-current-window))
 
+(defsubst doom-modeline-whitespace ()
+  (propertize " " 'face (if (doom-modeline--active) 'mode-line 'mode-line-inactive)))
+
 (defvar-local doom-modeline-project-root nil)
 (defun doom-modeline-project-root ()
   "Get the path to the root of your project.


### PR DESCRIPTION
I encountered some regressions, so here's some fixes and more.

* Fix for `Format specifier doesn't match argument type` error (4992a27)
* Fixes to a regression resulting to loss of color for some segments (de932ea, 88550d3)
* Try to get all the whitespace in segment separators propertized, so that they get the `mode-line-inactive` face when using `helm-M-x` (and others I guess) (8be3a04, 768083d)
* Change to checker text behaviour when the checker is running (aceb087)

Some of the changes might be unpleasant so take what you like, let me know if you want something changed.