### PR TITLE
Apply format-mode-line to mode-name in doom-modeline-segment--major-mode

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -485,7 +485,7 @@ directory, the file name, and its state (modified, read-only or non-existent)."
   (propertize
    (concat
     (doom-modeline-whitespace)
-    (propertize mode-name
+    (propertize (format-mode-line mode-name)
                 'help-echo "Major mode\n\
 mouse-1: Display major mode menu\n\
 mouse-2: Show help for major mode\n\


### PR DESCRIPTION
The mode-name variable can use any of the constructs for
mode-line-format, so this variable must be formatted before being
concatenated to another string.