### PR TITLE
Add icon for persp-name segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,12 +192,15 @@ Strongly recommend to use
 
 ;; If non-nil, only display one number for checker information if applicable.
 (setq doom-modeline-checker-simple-format t)
-  
+
 ;; The maximum displayed length of the branch name of version control.
 (setq doom-modeline-vcs-max-length 12)
 
 ;; Whether display perspective name or not. Non-nil to display in mode-line.
 (setq doom-modeline-persp-name t)
+
+;; Whether display icon for persp name. Nil to display a # sign. It respects `doom-modeline-icon'
+(setq doom-modeline-persp-name-icon nil)
 
 ;; Whether display `lsp' state or not. Non-nil to display in mode-line.
 (setq doom-modeline-lsp t)

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -189,6 +189,9 @@ If the actual char height is larger, it respects the actual char height.")
 (defvar doom-modeline-persp-name t
   "Whether display perspective name or not. Non-nil to display in mode-line.")
 
+(defvar doom-modeline-persp-name-icon nil
+  "Whether display icon for persp name. Nil to display a # sign. It respects `doom-modeline-icon'.")
+
 (defvar doom-modeline-lsp t
   "Whether display `lsp' state or not. Non-nil to display in mode-line.")
 

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1330,12 +1330,15 @@ Requires `eyebrowse-mode' to be enabled."
                    (fboundp 'safe-persp-name)
                    (fboundp 'get-current-persp))
           (let* ((persp (get-current-persp))
-                 (name (safe-persp-name persp)))
+                 (name (safe-persp-name persp))
+                 (icon (if (and doom-modeline-icon doom-modeline-persp-name-icon)
+                           (concat (doom-modeline-icon-material "aspect_ratio" :v-adjust -0.17) (doom-modeline-spc))
+                         "#")))
             (unless (string-equal persp-nil-name name)
               (concat
                (doom-modeline-spc)
                (propertize
-                (format "#%s" name)
+                (format "%s%s" icon name)
                 'face (if (and persp
                                (not (persp-contain-buffer-p (current-buffer) persp)))
                           'doom-modeline-persp-buffer-not-in-persp


### PR DESCRIPTION
Just a small change to provide an option to set icon before workspace name instead of # sign.
I picked material's aspect_ratio icon. Weird choice maybe, but it looks nice, I think.

![modeline](https://user-images.githubusercontent.com/1651444/60459160-cdc87680-9c59-11e9-8042-9efa7b1b142c.png)
