### PR TITLE
When `if-let*` or `when-let*` was defined, don't do alias for it.

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -37,11 +37,11 @@
 ;; Compatibilities
 ;;
 
-(unless (>= emacs-major-version 26)
-  (with-no-warnings
+(eval-and-compile
+  (unless (>= emacs-major-version 26)
     ;; Define `if-let*' and `when-let*' variants for 25 users.
-    (defalias 'if-let* #'if-let)
-    (defalias 'when-let* #'when-let)))
+    (unless (fboundp 'if-let*) (defalias 'if-let* #'if-let))
+    (unless (fboundp 'when-let*) (defalias 'when-let* #'when-let))))
 
 ;; Don’t compact font caches during GC.
 (if (eq system-type 'windows-nt)


### PR DESCRIPTION
Some package may alias it (or define a enhance version) before the loading of
`doom-modeline` (AFAIK, doom-emacs do this in the configuraion https://github.com/hlissner/doom-emacs/blob/c3c282f0a4f99945288f9e656b7684c0e970b630/core/core-lib.el#L14)

Use `eval-and-compile`, allow byte-compiler see through the form, is better than
using `with-no-warnings` to suppress it rigidly.