### PR TITLE
Evaluate docstrings in doom-modeline-def-env

### DIFF
--- a/doom-modeline-env.el
+++ b/doom-modeline-env.el
@@ -145,18 +145,18 @@ PARSER should be a function for parsing COMMAND's output line-by-line, to
         (exe-var     (intern (format "doom-modeline-env-%s-executable" name))))
     (macroexp-progn
      `((defcustom ,enable-var t
-         (format "Whether to display the version string for %s buffers." ',name)
+         ,(format "Whether to display the version string for %s buffers." name)
          :type 'boolean
          :group 'doom-modeline-env)
        (defvar ,command-var ',action-fn
-         (concat "A function that returns the shell command and arguments (as a list) to\n"
-                 "produce a version string."))
+         ,(concat "A function that returns the shell command and arguments (as a list) to\n"
+                  "produce a version string."))
        (defvar ,parser-var ',parse-fn
-         (format "The function for parsing each line of `%s's output." ',command-var))
+         ,(format "The function for parsing each line of `%s's output." command-var))
        (defcustom ,exe-var nil
-         (format (concat "What executable to use for the version indicator in %s buffers.\n\n"
-                         "If nil, the default binary for this language is used.")
-                 ',name)
+         ,(format (concat "What executable to use for the version indicator in %s buffers.\n\n"
+                          "If nil, the default binary for this language is used.")
+                  name)
          :type 'string
          :group 'doom-modeline-env)
        (defalias ',parse-fn ,parser


### PR DESCRIPTION
This fixes an issue where `apropos-documentation` iterates over obarray (with `mapatoms`). The `(concat ...)` and `(format ...)` forms are left unevaluated in some of these symbol's definitions, which causes the following error:

```
Debugger entered--Lisp error: (wrong-type-argument stringp concat)
  insert-file-contents(concat)
  apropos-documentation-check-elc-file(concat)
  apropos-documentation-internal((concat "A function that returns the shell command and arguments (as a list) to\n" "produce a version string."))
  #f(compiled-function (symbol) #<bytecode 0x490349>)(doom-modeline-env-python-command)
  mapatoms(#f(compiled-function (symbol) #<bytecode 0x490349>))
  apropos-documentation(("test") nil)
  funcall-interactively(apropos-documentation ("test") nil)
  call-interactively(apropos-documentation record nil)
  command-execute(apropos-documentation record)
  counsel-M-x-action("apropos-documentation")
  ivy-call()
  ivy-read("M-x " ("apropos" "apropos-documentation" "evil-mode" "org-store-link" "font-lock-mode" "so-long-minor-mode" "package-install" "package-refresh-contents" "whitespace-mode" "ibuffer" "doom/info" "transpose-words" "byte-compile-file" "counsel-find-symbol" "highlight-lines-matching-regexp" "grep" "doctor" "so-long" "server-start" "list-processes" "maximize-window" "server-force-delete" "dired-do-find-regexp" "select-frame-by-name" "straight-use-package" "highlight-numbers-mode" "toggle-frame-maximized" "calc" "eshell" "buffer-menu" "+popup/other" "+popup/raise" "load-library" "select-frame" "so-long-mode" "cider-jack-in" "revert-buffer" "set-frame-font" "cargo-process-rm" "dired-do-isearch" "doom/help-modules" "finder-by-keyword" "list-input-methods" "kill-current-buffer" "+doom-dashboard/open" "counsel-find-library" "cd" "5x5" "amx" "arp" ...) :predicate #f(compiled-function (x) #<bytecode 0x212843d>) :require-match t :history counsel-M-x-history :action counsel-M-x-action :keymap (keymap (67108908 . counsel--info-lookup-symbol) (67108910 . counsel-find-symbol)) :initial-input nil :caller counsel-M-x)
  counsel-M-x()
  funcall-interactively(counsel-M-x)
  call-interactively(counsel-M-x nil nil)
  command-execute(counsel-M-x)
```