### PR TITLE
inhibit bogus cursor jump.

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1121,8 +1121,8 @@ Requires `anzu', also `evil-anzu' if using `evil-mode' for compatibility with
     (propertize
      (let ((this-oc (or (let ((inhibit-message t))
                           (iedit-find-current-occurrence-overlay))
-                        (progn (iedit-prev-occurrence)
-                               (iedit-find-current-occurrence-overlay))))
+                        (save-excursion (iedit-prev-occurrence)
+                                        (iedit-find-current-occurrence-overlay))))
            (length (length iedit-occurrences-overlays)))
        (format " %s/%d "
                (if this-oc


### PR DESCRIPTION
Or else the cursor jumps after overlays become empty.

here is a full frame reproducing video https://la.wentropy.com/doXC.webm
