### PR TITLE
Fix double space after "checker" segment.

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1006,11 +1006,12 @@ mouse-1: List all problems%s"
                  icon
                (propertize icon 'face `(:inherit ,(get-text-property 0 'face icon)
                                         :inherit mode-line-inactive))))
-           (doom-modeline-vspc)
            (when text
-             (if active
-                 text
-               (propertize text 'face 'mode-line-inactive)))))
+             (concat
+              (doom-modeline-vspc)
+              (if active
+                  text
+                (propertize text 'face 'mode-line-inactive))))))
       "")))
 
 


### PR DESCRIPTION
If there is no checker text (i.e. no errors), you were ending up with
two spaces after the checker icon. Fix by moving the second space into
the "text" conditional.

Before:
<img width="833" alt="Screen Shot 2019-10-27 at 11 21 51 AM" src="https://user-images.githubusercontent.com/11356572/67639571-b8cdbe00-f8ae-11e9-86fe-6711e6d1de10.png">

After:
<img width="833" alt="Screen Shot 2019-10-27 at 11 24 00 AM" src="https://user-images.githubusercontent.com/11356572/67639572-bc614500-f8ae-11e9-984e-401d2a4c46be.png">
