### PR TITLE
Fix tramp multihop file opening

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -267,7 +267,9 @@ Uses `all-the-icons-material' to fetch the icon."
                  (doom-modeline-buffer-file-state-icon
                   "save" "💾" "%1*" 'doom-modeline-buffer-modified))
                 ((and buffer-file-name
-                      (not (file-exists-p buffer-file-name)))
+                      (or
+                       (string= _ " *temp*")
+                       (not (file-exists-p buffer-file-name))))
                  (doom-modeline-buffer-file-state-icon
                   "do_not_disturb_alt" "🚫" "!" 'doom-modeline-urgent))
                 ((or (buffer-narrowed-p)


### PR DESCRIPTION
This fixes #244 for me, but I'm new to elisp and doom-modeline's codebase. So checking just that the parameter given to `doom-modeline-update-buffer-file-state-icon` equals ` *temp*` to avoid calling `(file-exists-p buffer-file-name)` (which then causes an infinite recursion) might be inelegant, too narrow and not free of unwanted side-effects?