### PR TITLE
Introduce `doom-modeline-display-default-perspective-name`

### DIFF
--- a/doom-modeline-env.el
+++ b/doom-modeline-env.el
@@ -57,6 +57,11 @@
   :type 'hook
   :group 'doom-modeline-env)
 
+(defcustom doom-modeline-display-default-perspective-name nil
+  "If non nil the default perspective name is displayed in the mode-line."
+  :type 'boolean
+  :group 'doom-modeline-env)
+
 ;; Show version string for multi-version managers like rvm, rbenv, pyenv, etc.
 (defvar-local doom-modeline-env--version nil
   "The version to display with major-mode in mode-line.

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1404,7 +1404,8 @@ Requires `eyebrowse-mode' to be enabled."
                                            `(:inherit ,face :slant normal)
                                            :height 1.1
                                            :v-adjust -0.225)))
-            (unless (string-equal persp-nil-name name)
+            (if (or doom-modeline-display-default-perspective-name
+                    (not (string-equal persp-nil-name name)))
               (concat (doom-modeline-spc)
                       (propertize (concat icon
                                           (doom-modeline-vspc)


### PR DESCRIPTION
Adds a customizable option to toggle displaying the default perspective's name
on the modeline. Updates `doom-modeline-update-persp-name` to respect it.

Fixes #261 