### PR TITLE
Add continuously displayed word count segment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ Run `M-x customize-group RET doom-modeline RET` or set the variables.
 (setq doom-modeline-enable-word-count nil)
 
 ;; Major modes in which to display word count continuously.
-;; Respects `doom-modeline-enable-word-count'.
-(setq doom-modeline-continuous-word-count-modes '(markdown-mode org-mode))
+;; Also applies to any derived modes. Respects `doom-modeline-enable-word-count'.
+(setq doom-modeline-continuous-word-count-modes '(text-mode))
 
 ;; Whether display the buffer encoding.
 (setq doom-modeline-buffer-encoding t)

--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ Run `M-x customize-group RET doom-modeline RET` or set the variables.
 ;; If non-nil, a word count will be added to the selection-info modeline segment.
 (setq doom-modeline-enable-word-count nil)
 
+;; Major modes in which to display word count continuously.
+;; Respects `doom-modeline-enable-word-count'.
+(setq doom-modeline-continuous-word-count-modes '(markdown-mode org-mode))
+
 ;; Whether display the buffer encoding.
 (setq doom-modeline-buffer-encoding t)
 

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -248,6 +248,13 @@ It respects `doom-modeline-icon' and `doom-modeline-buffer-state-icon'."
   :type 'boolean
   :group 'doom-modeline)
 
+(defcustom doom-modeline-continuous-word-count-modes
+  '(markdown-mode org-mode)
+  "Major modes in which to display word count continuously.
+Respects `doom-modeline-enable-word-count'."
+  :type 'list
+  :group 'doom-modeline)
+
 (defcustom doom-modeline-buffer-encoding t
   "Whether display the buffer encoding."
   :type 'boolean

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -249,9 +249,9 @@ It respects `doom-modeline-icon' and `doom-modeline-buffer-state-icon'."
   :group 'doom-modeline)
 
 (defcustom doom-modeline-continuous-word-count-modes
-  '(markdown-mode org-mode)
+  '(text-mode)
   "Major modes in which to display word count continuously.
-Respects `doom-modeline-enable-word-count'."
+Also applies to any derived modes. Respects `doom-modeline-enable-word-count'."
   :type 'list
   :group 'doom-modeline)
 

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1024,6 +1024,18 @@ mouse-1: List all problems%s"
            (doom-modeline-spc)))
       "")))
 
+;;
+;; Word Count
+;;
+
+(doom-modeline-def-segment word-count
+  "The buffer word count.
+Displayed when in a major mode in `doom-modeline-continuous-word-count-modes'.
+Respects `doom-modeline-enable-word-count'."
+  (when (and doom-modeline-enable-word-count
+             (doom-modeline--active)
+             (member major-mode doom-modeline-continuous-word-count-modes))
+    (format " %dW" (count-words (point-min) (point-max)))))
 
 ;;
 ;; Selection

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1033,9 +1033,11 @@ mouse-1: List all problems%s"
 Displayed when in a major mode in `doom-modeline-continuous-word-count-modes'.
 Respects `doom-modeline-enable-word-count'."
   (when (and doom-modeline-enable-word-count
-             (doom-modeline--active)
              (member major-mode doom-modeline-continuous-word-count-modes))
-    (format " %dW" (count-words (point-min) (point-max)))))
+    (let ((word-count (format " %dW" (count-words (point-min) (point-max)))))
+      (if (doom-modeline--active)
+          word-count
+        (propertize word-count 'face 'mode-line-inactive)))))
 
 ;;
 ;; Selection

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1030,10 +1030,10 @@ mouse-1: List all problems%s"
 
 (doom-modeline-def-segment word-count
   "The buffer word count.
-Displayed when in a major mode in `doom-modeline-continuous-word-count-modes'.
-Respects `doom-modeline-enable-word-count'."
+Displayed when in a major mode in `doom-modeline-continuous-word-count-modes',
+or any derived mode. Respects `doom-modeline-enable-word-count'."
   (when (and doom-modeline-enable-word-count
-             (member major-mode doom-modeline-continuous-word-count-modes))
+             (apply #'derived-mode-p doom-modeline-continuous-word-count-modes))
     (let ((word-count (format " %dW" (count-words (point-min) (point-max)))))
       (if (doom-modeline--active)
           word-count

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1035,9 +1035,9 @@ or any derived mode. Respects `doom-modeline-enable-word-count'."
   (when (and doom-modeline-enable-word-count
              (apply #'derived-mode-p doom-modeline-continuous-word-count-modes))
     (let ((word-count (format " %dW" (count-words (point-min) (point-max)))))
-      (if (doom-modeline--active)
-          word-count
-        (propertize word-count 'face 'mode-line-inactive)))))
+      (propertize word-count 'face (if (doom-modeline--active)
+                                       'mode-line
+                                     'mode-line-inactive)))))
 
 ;;
 ;; Selection

--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -89,7 +89,7 @@
 ;;
 
 (doom-modeline-def-modeline 'main
-  '(bar workspace-name window-number modals matches buffer-info remote-host buffer-position parrot selection-info)
+  '(bar workspace-name window-number modals matches buffer-info remote-host buffer-position parrot word-count selection-info)
   '(objed-state misc-info persp-name battery grip irc mu4e github debug lsp minor-modes input-method indent-info buffer-encoding major-mode process vcs checker))
 
 (doom-modeline-def-modeline 'minimal


### PR DESCRIPTION
In case it's useful: 

This patch introduces `doom-modeline-continuous-word-count-modes`, a customizable list of major modes in which a word count is displayed continuously. Also applies to derived modes. Respects `doom-modeline-enable-word-count`.

```lisp
;; Major modes in which to display word count continuously.
;; Respects `doom-modeline-enable-word-count'.
(setq doom-modeline-continuous-word-count-modes '(text-mode))
```

![demo](https://user-images.githubusercontent.com/4433943/69488680-cbe69600-0e3a-11ea-9317-89139eb595de.gif)
