### PR TITLE
Add basic Gnus support without any other dependency than gnus

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The `doom-modeline` was designed for minimalism, and offers:
 - An indicator for remote host
 - An indicator for LSP state with `lsp-mode` or `eglot`
 - An indicator for GitHub notifications
-- An indicator for unread emails with `mu4e-alert`
+- An indicator for unread emails with `mu4e-alert` and `gnus`
 - An indicator for IRC notifications with `circe`, `rcirc` or `erc`
 - An indicator for buffer position which is compatible with `nyan-mode`
 - An indicator for party `parrot`
@@ -266,6 +266,12 @@ Run `M-x customize-group RET doom-modeline RET` or set the variables.
 
 ;; Whether display the mu4e notifications. It requires `mu4e-alert' package.
 (setq doom-modeline-mu4e t)
+
+;; Whether display the gnus notifications.
+(setq doom-modeline-gnus t)
+
+;; Wheter gnus should automatically be updated and how often (set to nil to disable)
+(setq doom-modeline-gnus-timer 2)
 
 ;; Whether display the IRC notifications. It requires `circe' or `erc' package.
 (setq doom-modeline-irc t)

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -330,6 +330,20 @@ It requires `mu4e-alert' package."
   :type 'boolean
   :group 'doom-modeline)
 
+(defcustom doom-modeline-gnus nil
+  "Wheter to display notifications from gnus
+
+It requires `gnus' to be setup"
+  :type 'boolean
+  :group 'doom-modeline)
+
+(defcustom doom-modeline-gnus-timer 2
+  "The wait time in minutes before gnus fetches mail
+
+if nil, don't set up a hook"
+  :type 'integer
+  :group 'doom-modeline)
+
 (defcustom doom-modeline-irc t
   "Whether display the irc notifications.
 

--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -54,6 +54,7 @@
 ;; - An indicator for LSP state with lsp-mode or eglot
 ;; - An indicator for github notifications
 ;; - An indicator for unread emails with mu4e-alert
+;; - An indicator for unread emails with gnus (basically builtin)
 ;; - An indicator for irc notifications with circe, rcirc or erc.
 ;; - An indicator for buffer position which is compatible with nyan-mode
 ;; - An indicator for party parrot
@@ -90,7 +91,7 @@
 
 (doom-modeline-def-modeline 'main
   '(bar workspace-name window-number modals matches buffer-info remote-host buffer-position word-count parrot selection-info)
-  '(objed-state misc-info persp-name battery grip irc mu4e github debug lsp minor-modes input-method indent-info buffer-encoding major-mode process vcs checker))
+  '(objed-state misc-info persp-name battery grip irc mu4e gnus github debug lsp minor-modes input-method indent-info buffer-encoding major-mode process vcs checker))
 
 (doom-modeline-def-modeline 'minimal
   '(bar matches buffer-info-simple)
@@ -102,11 +103,11 @@
 
 (doom-modeline-def-modeline 'project
   '(bar window-number buffer-default-directory)
-  '(misc-info battery irc mu4e github debug major-mode process))
+  '(misc-info battery irc mu4e gnus github debug major-mode process))
 
 (doom-modeline-def-modeline 'vcs
   '(bar window-number modals matches buffer-info buffer-position parrot selection-info)
-  '(misc-info battery irc mu4e github debug minor-modes buffer-encoding major-mode process))
+  '(misc-info battery irc mu4e gnus github debug minor-modes buffer-encoding major-mode process))
 
 (doom-modeline-def-modeline 'package
   '(bar window-number package)


### PR DESCRIPTION
A rather simple implementation of a `Gnus` mail notification handler.
I created it so that if enabled, it also fetches new mails automatically all 2 minutes per default. I think people might like this because otherwise they need another plugin or custom code in their config. It could also be deactivated per default, but since notifications are only shown when gnus runs and since I couldn't find any "better" way to search for mails I figured this is probably the standard way for most people anyways.
The variable can be modified to change the timeout between fetches, or to disable any automatic updates by setting it to `nil`.

Also I coldheartedly copied the `unread mail counter lambda` in the function `doom-modeline-update-gnus-status` from [gnus-notify+](https://www.emacswiki.org/emacs/gnus-notify%2B.el).

Another thing i made deliberately is showing a greyed out `0 mails` indicator as long as gnus is running in the background. I consider this important as it happens quite quickly to me that I stop gnus and not get any notifications at all anymore. This way I know if there is no counter, there is no new mail.

PS: This is my first ever Lisp code not being in my configuration. I hope the code is not too ugly and I'm glad for any constructive critique :)