### PR TITLE
Check before displaying icon for buffer-default-directory

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -216,9 +216,11 @@ buffer where knowing the current project directory is important."
   (let* ((active (doom-modeline--active))
          (face (if active 'doom-modeline-buffer-path 'mode-line-inactive)))
     (concat (doom-modeline-spc)
-            (doom-modeline-icon 'octicon "file-directory" "🖿" ""
-                                :face face :v-adjust -0.05 :height 1.25)
-            (doom-modeline-spc)
+            (cond (doom-modeline-major-mode-icon
+                   (concat (doom-modeline-icon
+                            'octicon "file-directory" "🖿" ""
+                            :face face :v-adjust -0.05 :height 1.25)
+                           (doom-modeline-spc))))
             (propertize (abbreviate-file-name default-directory)
                         'face face))))
 


### PR DESCRIPTION
If doom-modeline-major-mode-icon is nil, we should not show the
file-directory icon for buffer-default-directory segment.