### PR TITLE
buffer-info: add `truncate-nil` style

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Run `M-x customize-group RET doom-modeline RET` or set the variables.
 ;;   truncate-except-project => ~/P/F/emacs/l/comint.el
 ;;   truncate-upto-root => ~/P/F/e/lisp/comint.el
 ;;   truncate-all => ~/P/F/e/l/comint.el
+;;   truncate-nil => ~/Projects/FOSS/emacs/lisp/comint.el
 ;;   relative-from-project => emacs/lisp/comint.el
 ;;   relative-to-project => lisp/comint.el
 ;;   file-name => comint.el

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -187,6 +187,7 @@ Given ~/Projects/FOSS/emacs/lisp/comint.el
   truncate-except-project => ~/P/F/emacs/l/comint.el
   truncate-upto-root => ~/P/F/e/lisp/comint.el
   truncate-all => ~/P/F/e/l/comint.el
+  truncate-nil => ~/Projects/FOSS/emacs/lisp/comint.el
   relative-from-project => emacs/lisp/comint.el
   relative-to-project => lisp/comint.el
   file-name => comint.el
@@ -199,6 +200,7 @@ Given ~/Projects/FOSS/emacs/lisp/comint.el
                  (const truncate-except-project)
                  (const truncate-upto-root)
                  (const truncate-all)
+                 (const truncate-nil)
                  (const relative-from-project)
                  (const relative-to-project)
                  (const file-name)
@@ -1010,6 +1012,8 @@ directory too."
              (doom-modeline--buffer-file-name-truncate buffer-file-name buffer-file-truename))
             ('truncate-all
              (doom-modeline--buffer-file-name-truncate buffer-file-name buffer-file-truename t))
+            ('truncate-nil
+             (doom-modeline--buffer-file-name buffer-file-name buffer-file-truename nil))
             ('relative-to-project
              (doom-modeline--buffer-file-name-relative buffer-file-name buffer-file-truename))
             ('relative-from-project

--- a/test/doom-modeline-core-test.el
+++ b/test/doom-modeline-core-test.el
@@ -213,6 +213,16 @@
        (string= (substring-no-properties (doom-modeline-buffer-file-name))
                 "/h/u/p/r/test.txt")))))
 
+(ert-deftest doom-modeline-buffer-file-name/truncate-nil ()
+  (let ((default-directory "/home/user/project/")
+        (buffer-file-name "/home/user/project/relative/test.txt")
+        (buffer-file-truename "/home/user/project/relative/test.txt")
+        (doom-modeline-buffer-file-name-style 'truncate-nil))
+    (cl-flet ((doom-modeline-project-root () default-directory))
+      (should
+       (string= (substring-no-properties (doom-modeline-buffer-file-name))
+                "/home/user/project/relative/test.txt")))))
+
 (ert-deftest doom-modeline-buffer-file-name/relative-to-project ()
   (let ((default-directory "/home/user/project/")
         (buffer-file-name "/home/user/project/relative/test.txt")
@@ -294,6 +304,16 @@
      (string= (substring-no-properties
                (doom-modeline--buffer-file-name-truncate file-path true-file-path t))
               "/h/u/p/r/test.txt"))))
+
+(ert-deftest doom-modeline--buffer-file-name/truncate-nil ()
+  (let ((default-directory "/home/user/project/")
+        (file-path "/home/user/project/relative/test.txt")
+        (true-file-path nil)
+        (doom-modeline--project-detected-p t))
+    (should
+     (string= (substring-no-properties
+               (doom-modeline--buffer-file-name file-path true-file-path 'nil))
+              "/home/user/project/relative/test.txt"))))
 
 (ert-deftest doom-modeline--buffer-file-name-relative/relative-to-project ()
   (let ((default-directory "/home/user/project/")


### PR DESCRIPTION
Hi, I could'nt find any other way to show full buffer-info. Is this PR alright?  