### PR TITLE
Make persp mode indicator icon toggleable

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Run `M-x customize-group RET doom-modeline RET` or set the variables.
 (setq doom-modeline-display-default-persp-name nil)
 
 ;; If non nil the perspective name is displayed alongside a folder icon.
-(setq doom-modeline-display-persp-icon t)
+(setq doom-modeline-persp-icon t)
 
 ;; Whether display the `lsp' state. Non-nil to display in the mode-line.
 (setq doom-modeline-lsp t)

--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ Run `M-x customize-group RET doom-modeline RET` or set the variables.
 ;; If non nil the default perspective name is displayed in the mode-line.
 (setq doom-modeline-display-default-persp-name nil)
 
+;; If non nil the perspective name is displayed alongside a folder icon.
+(setq doom-modeline-display-persp-icon t)
+
 ;; Whether display the `lsp' state. Non-nil to display in the mode-line.
 (setq doom-modeline-lsp t)
 

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -303,7 +303,7 @@ Non-nil to display in the mode-line."
   :type 'boolean
   :group 'doom-modeline)
 
-(defcustom doom-modeline-display-persp-icon t
+(defcustom doom-modeline-persp-icon t
   "If non nil the perspective name is displayed alongside a folder icon."
   :type 'boolean
   :group 'doom-modeline)

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -303,6 +303,11 @@ Non-nil to display in the mode-line."
   :type 'boolean
   :group 'doom-modeline)
 
+(defcustom doom-modeline-display-persp-icon t
+  "If non nil the perspective name is displayed alongside a folder icon."
+  :type 'boolean
+  :group 'doom-modeline)
+
 (defcustom doom-modeline-lsp t
   "Whether display the `lsp' state.
 

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1433,8 +1433,8 @@ Requires `eyebrowse-mode' or `tab-bar-mode' to be enabled."
             (when (or doom-modeline-display-default-persp-name
                       (not (string-equal persp-nil-name name)))
               (concat (doom-modeline-spc)
-                      (propertize (concat (and doom-modeline-display-persp-icon icon)
-                                          (doom-modeline-vspc)
+                      (propertize (concat (and doom-modeline-persp-icon
+                                               (concat icon (doom-modeline-vsp)))
                                           (propertize name 'face face))
                                   'help-echo "mouse-1: Switch perspective
 mouse-2: Show help for minor mode"

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1433,7 +1433,7 @@ Requires `eyebrowse-mode' or `tab-bar-mode' to be enabled."
             (when (or doom-modeline-display-default-persp-name
                       (not (string-equal persp-nil-name name)))
               (concat (doom-modeline-spc)
-                      (propertize (concat icon
+                      (propertize (concat (and doom-modeline-display-persp-icon icon)
                                           (doom-modeline-vspc)
                                           (propertize name 'face face))
                                   'help-echo "mouse-1: Switch perspective

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1433,8 +1433,8 @@ Requires `eyebrowse-mode' or `tab-bar-mode' to be enabled."
             (when (or doom-modeline-display-default-persp-name
                       (not (string-equal persp-nil-name name)))
               (concat (doom-modeline-spc)
-                      (propertize (concat (and doom-modeline-persp-icon
-                                               (concat icon (doom-modeline-vspc)))
+                      (propertize (concat (when doom-modeline-persp-icon
+                                                (concat icon (doom-modeline-vspc)))
                                           (propertize name 'face face))
                                   'help-echo "mouse-1: Switch perspective
 mouse-2: Show help for minor mode"

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1434,7 +1434,7 @@ Requires `eyebrowse-mode' or `tab-bar-mode' to be enabled."
                       (not (string-equal persp-nil-name name)))
               (concat (doom-modeline-spc)
                       (propertize (concat (and doom-modeline-persp-icon
-                                               (concat icon (doom-modeline-vsp)))
+                                               (concat icon (doom-modeline-vspc)))
                                           (propertize name 'face face))
                                   'help-echo "mouse-1: Switch perspective
 mouse-2: Show help for minor mode"


### PR DESCRIPTION
By default the persp name is displayed with a folder icon. This patch makes the
icon toggleable via `doom-modeline-persp-icon`.

Before:

<img width="545" alt="Screen Shot 2020-04-23 at 7 38 20 AM" src="https://user-images.githubusercontent.com/4433943/80095357-c7cbbb00-8535-11ea-99d1-c11e624bcd6c.png">



After:

<img width="485" alt="Screen Shot 2020-04-23 at 7 39 18 AM" src="https://user-images.githubusercontent.com/4433943/80095250-9ce16700-8535-11ea-9aa0-bbb0e46f9ad5.png">

