### PR TITLE
Enable global-anzu-mode

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1110,7 +1110,8 @@ lines are selected, or the NxM dimensions of a block selection."
         '(anzu--total-matched
           anzu--current-position anzu--state anzu--cached-count
           anzu--cached-positions anzu--last-command
-          anzu--last-isearch-string anzu--overflow-p)))
+          anzu--last-isearch-string anzu--overflow-p))
+  (global-anzu-mode +1))
 
 (defsubst doom-modeline--anzu ()
   "Show the match index and total number thereof.


### PR DESCRIPTION
Due to emacsorphanage/evil-anzu@8c80e184f9, `evil-anzu` doesn't update its results (and thus no anzu segment is shown) unless `anzu-mode` is active, so we enable it globally.