### PR TITLE
[FIX] gnus update status error

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,9 @@ Run `M-x customize-group RET doom-modeline RET` or set the variables.
 ;; Wheter gnus should automatically be updated and how often (set to 0 or smaller than 0 to disable)
 (setq doom-modeline-gnus-timer 2)
 
+;; Wheter groups should be excludede when gnus automatically being updated.
+(setq doom-modeline-gnus-excluded-groups '("dummy.group"))
+
 ;; Whether display the IRC notifications. It requires `circe' or `erc' package.
 (setq doom-modeline-irc t)
 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Run `M-x customize-group RET doom-modeline RET` or set the variables.
 ;; Whether display the gnus notifications.
 (setq doom-modeline-gnus t)
 
-;; Wheter gnus should automatically be updated and how often (set to nil to disable)
+;; Wheter gnus should automatically be updated and how often (set to 0 or smaller than 0 to disable)
 (setq doom-modeline-gnus-timer 2)
 
 ;; Whether display the IRC notifications. It requires `circe' or `erc' package.

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -361,7 +361,7 @@ If nil, don't set up a hook."
   :group 'doom-modeline)
 
 (defcustom doom-modeline-gnus-excluded-groups nil
-  "A list of groups to be excluded from the unread count."
+  "A list of groups to be excluded from the unread count. A group name list in `gnus-newsrc-alist'`"
 
   :type '(repeat string)
   :group 'doom-modeline)

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -361,7 +361,7 @@ If nil, don't set up a hook."
   :group 'doom-modeline)
 
 (defcustom doom-modeline-gnus-excluded-groups nil
-  "A list of groups to be excluded from the unread count. A group name list in `gnus-newsrc-alist'`"
+  "A list of groups to be excluded from the unread count. Groups' names list in `gnus-newsrc-alist'`"
 
   :type '(repeat string)
   :group 'doom-modeline)

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -2149,7 +2149,7 @@ mouse-1: Toggle Debug on Quit"
             (mapc (lambda (g)
                     (let* ((group (car g))
                            (unread (eval `(gnus-group-unread ,group))))
-                      (when (and (not (seq-contains-p doom-modeline-gnus-excluded-groups group))
+                      (when (and (not (seq-contains doom-modeline-gnus-excluded-groups group))
                                  (numberp unread)
                                  (> unread 0))
                         (setq total-unread-news-number (+ total-unread-news-number unread)))))

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -2148,8 +2148,7 @@ mouse-1: Toggle Debug on Quit"
           (let ((total-unread-news-number 0))
             (mapc (lambda (g)
                     (let* ((group (car g))
-                           ;; `gnus-group-unread' is a macro
-                           (unread (car (gethash group gnus-newsrc-hashtb))))
+                           (unread (eval `(gnus-group-unread ,group))))
                       (when (and (not (seq-contains-p doom-modeline-gnus-excluded-groups group))
                                  (numberp unread)
                                  (> unread 0))


### PR DESCRIPTION
Some description， fix #342.

**Modification**
1. fix `gethash` error
2. fix `seq-contains-p` in `seq.el`
3. add readme description

**Note**
1. I use `eval` instead of coding an expanded-macro, which is more compatible in my opinion.
2.  I __ONLY__ test it on Emacs 26.3 with `seq` and `gnus`. 
    - `seq.el` has not `seq-contains-p` on my emacs version 26.3
    - `gnus-group-unread` defination is different from the HEAD(2b308857677e983ca4eaedc36438ed94aadf9e65)
3. add some description in readme