### PR TITLE
[debug] fix modeline color change for all buffers

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1960,7 +1960,7 @@ mouse-3: Fetch notifications"
 ;;
 
 ;; Highlight the mode-line while debugging.
-(defvar doom-modeline--debug-cookie nil)
+(defvar-local doom-modeline--debug-cookie nil)
 (defun doom-modeline--debug-visual (&rest _)
   "Update the face of mode-line for debugging."
   (mapc (lambda (buffer)
@@ -1973,8 +1973,8 @@ mouse-3: Fetch notifications"
 (defun doom-modeline--normal-visual (&rest _)
   "Restore the face of mode-line."
   (mapc (lambda (buffer)
-          (when doom-modeline--debug-cookie
-            (with-current-buffer buffer
+          (with-current-buffer buffer
+            (when doom-modeline--debug-cookie
               (face-remap-remove-relative doom-modeline--debug-cookie)
               (force-mode-line-update))))
         (buffer-list)))

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1960,18 +1960,24 @@ mouse-3: Fetch notifications"
 ;;
 
 ;; Highlight the mode-line while debugging.
-(defvar-local doom-modeline--debug-cookie nil)
+(defvar doom-modeline--debug-cookie nil)
 (defun doom-modeline--debug-visual (&rest _)
   "Update the face of mode-line for debugging."
-  (setq doom-modeline--debug-cookie
-        (face-remap-add-relative 'mode-line 'doom-modeline-debug-visual))
-  (force-mode-line-update))
+  (mapc (lambda (buffer)
+          (with-current-buffer buffer
+            (setq doom-modeline--debug-cookie
+                  (face-remap-add-relative 'mode-line 'doom-modeline-debug-visual))
+            (force-mode-line-update)))
+        (buffer-list)))
 
 (defun doom-modeline--normal-visual (&rest _)
   "Restore the face of mode-line."
-  (when doom-modeline--debug-cookie
-    (face-remap-remove-relative doom-modeline--debug-cookie)
-    (force-mode-line-update)))
+  (mapc (lambda (buffer)
+          (when doom-modeline--debug-cookie
+            (with-current-buffer buffer
+              (face-remap-remove-relative doom-modeline--debug-cookie)
+              (force-mode-line-update))))
+        (buffer-list)))
 
 (add-hook 'dap-session-created-hook #'doom-modeline--debug-visual)
 (add-hook 'dap-terminated-hook #'doom-modeline--normal-visual)


### PR DESCRIPTION
Fixes #327 

As discussed [here](https://github.com/seagle0128/doom-modeline/issues/327#issuecomment-635456086), we need to update other buffers when debug session is started/terminated. 

This is not the best way to handle the problem but it's a start I think.