### PR TITLE
Add repl segment for CIDER

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -98,6 +98,9 @@ It returns a file name which can be used directly as argument of
           ;; Preview
           ?\xe8a0                      ; pageview
 
+          ;; REPL
+          ?\xf155                      ; dollar-sign
+
           ;; LSP
           ?\xf135                      ; rocket
 
@@ -304,6 +307,13 @@ Non-nil to display in the mode-line."
 
 (defcustom doom-modeline-persp-icon t
   "If non nil the perspective name is displayed alongside a folder icon."
+  :type 'boolean
+  :group 'doom-modeline)
+
+(defcustom doom-modeline-repl t
+  "Whether display the `repl' state.
+
+Non-nil to display in the mode-line."
   :type 'boolean
   :group 'doom-modeline)
 
@@ -541,6 +551,16 @@ It requires `circe' or `erc' package."
 (defface doom-modeline-persp-buffer-not-in-persp
   '((t (:inherit (font-lock-doc-face bold italic))))
   "Face for the buffers which are not in the persp."
+  :group 'doom-modeline-faces)
+
+(defface doom-modeline-repl-success
+  '((t (:inherit success :weight normal)))
+  "Face for REPL success state."
+  :group 'doom-modeline-faces)
+
+(defface doom-modeline-repl-warning
+  '((t (:inherit warning :weight normal)))
+  "Face for REPL warning state."
   :group 'doom-modeline-faces)
 
 (defface doom-modeline-lsp-success

--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -91,7 +91,7 @@
 
 (doom-modeline-def-modeline 'main
   '(bar workspace-name window-number modals matches buffer-info remote-host buffer-position word-count parrot selection-info)
-  '(objed-state misc-info persp-name battery grip irc mu4e gnus github debug lsp minor-modes input-method indent-info buffer-encoding major-mode process vcs checker))
+  '(objed-state misc-info persp-name battery grip irc mu4e gnus github debug repl lsp minor-modes input-method indent-info buffer-encoding major-mode process vcs checker))
 
 (doom-modeline-def-modeline 'minimal
   '(bar matches buffer-info-simple)


### PR DESCRIPTION
Add a REPL segment: 
![image](https://user-images.githubusercontent.com/7820865/84161217-6c05b480-aa45-11ea-80cb-b0e2485faabd.png)

Currently, the REPL segment is activated when `cider-mode` is enabled or connected.
On the future we can use the same segment for other repl features from other languages too.

Closes https://github.com/seagle0128/doom-modeline/issues/347#issuecomment-640240103

