### PR TITLE
Fixed modeline width between emacs and emacsclient

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -789,7 +789,8 @@ then this function does nothing."
   "Cache the font width."
   (let ((attributes (face-all-attributes 'mode-line)))
     (or (cdr (assoc attributes doom-modeline--font-width-cache))
-        (let ((width (if (server-running-p) (window-width)
+        (let ((width (if (and (fboundp 'server-running-p) (server-running-p)) 
+                              (window-width)
                        (window-font-width nil 'mode-line))))
           (push (cons attributes width) doom-modeline--font-width-cache)
           width))))

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -789,7 +789,8 @@ then this function does nothing."
   "Cache the font width."
   (let ((attributes (face-all-attributes 'mode-line)))
     (or (cdr (assoc attributes doom-modeline--font-width-cache))
-        (let ((width (window-font-width nil 'mode-line)))
+        (let ((width (if (server-running-p) (window-width)
+                       (window-font-width nil 'mode-line))))
           (push (cons attributes width) doom-modeline--font-width-cache)
           width))))
 


### PR DESCRIPTION
Added a condition in which, if an emacs daemon is running in the background, the correct window size is chosen via `window-width`. If a normal emacs istance is running, use instead `window-font-width` as usual. 

Only edge case is if someone opens a standalone emacs istance while running an emacs daemon, but i didn't think it was worth handling it since if someone uses standalone emacs then they are not running the daemon.