### PR TITLE
Improve indent info by showing correct indent size by major mode

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -278,6 +278,116 @@ It respects `doom-modeline-enable-word-count'."
   :type 'boolean
   :group 'doom-modeline)
 
+;; It is based upon `editorconfig-indentation-alist' but is used to read indentation levels instead
+;; of setting them. (https://github.com/editorconfig/editorconfig-emacs)
+(defcustom doom-modeline-indent-alist
+  '((apache-mode apache-indent-level)
+    (awk-mode c-basic-offset)
+    (bpftrace-mode c-basic-offset)
+    (c++-mode c-basic-offset)
+    (c-mode c-basic-offset)
+    (cmake-mode cmake-tab-width)
+    (coffee-mode coffee-tab-width)
+    (cperl-mode cperl-indent-level)
+    (crystal-mode crystal-indent-level)
+    (csharp-mode c-basic-offset)
+    (css-mode css-indent-offset)
+    (d-mode c-basic-offset)
+    (emacs-lisp-mode lisp-indent-offset)
+    (enh-ruby-mode enh-ruby-indent-level)
+    (erlang-mode erlang-indent-level)
+    (ess-mode ess-indent-offset)
+    (f90-mode f90-associate-indent
+              f90-continuation-indent
+              f90-critical-indent
+              f90-do-indent
+              f90-if-indent
+              f90-program-indent
+              f90-type-indent)
+    (feature-mode feature-indent-offset
+                  feature-indent-level)
+    (fsharp-mode fsharp-continuation-offset
+                 fsharp-indent-level
+                 fsharp-indent-offset)
+    (groovy-mode groovy-indent-offset)
+    (haskell-mode haskell-indent-spaces
+                  haskell-indent-offset
+                  haskell-indentation-layout-offset
+                  haskell-indentation-left-offset
+                  haskell-indentation-starter-offset
+                  haskell-indentation-where-post-offset
+                  haskell-indentation-where-pre-offset
+                  shm-indent-spaces)
+    (haxor-mode haxor-tab-width)
+    (idl-mode c-basic-offset)
+    (jade-mode jade-tab-width)
+    (java-mode c-basic-offset)
+    (js-mode js-indent-level)
+    (js-jsx-mode js-indent-level
+                 sgml-basic-offset)
+    (js2-mode js2-basic-offset)
+    (js2-jsx-mode js2-basic-offset
+                  sgml-basic-offset)
+    (js3-mode js3-indent-level)
+    (json-mode js-indent-level)
+    (julia-mode julia-indent-offset)
+    (kotlin-mode kotlin-tab-width)
+    (latex-mode tex-indent-basic)
+    (lisp-mode lisp-indent-offset)
+    (livescript-mode livescript-tab-width)
+    (lua-mode lua-indent-level)
+    (matlab-mode matlab-indent-level)
+    (mips-mode mips-tab-width)
+    (mustache-mode mustache-basic-offset)
+    (nasm-mode nasm-basic-offset)
+    (nginx-mode nginx-indent-level)
+    (nxml-mode nxml-child-indent)
+    (objc-mode c-basic-offset)
+    (octave-mode octave-block-offset)
+    (perl-mode perl-indent-level)
+    (php-mode c-basic-offset)
+    (pike-mode c-basic-offset)
+    (ps-mode ps-mode-tab)
+    (pug-mode pug-tab-width)
+    (puppet-mode puppet-indent-level)
+    (python-mode python-indent-offset)
+    (ruby-mode ruby-indent-level)
+    (rust-mode rust-indent-offset)
+    (rustic-mode rustic-indent-offset)
+    (scala-mode scala-indent:step)
+    (scss-mode css-indent-offset)
+    (sgml-mode sgml-basic-offset)
+    (sh-mode sh-basic-offset
+             sh-indentation)
+    (slim-mode slim-indent-offset)
+    (sml-mode sml-indent-level)
+    (tcl-mode tcl-indent-level
+              tcl-continued-indent-level)
+    (terra-mode terra-indent-level)
+    (typescript-mode typescript-indent-level)
+    (verilog-mode verilog-indent-level
+                  verilog-indent-level-behavioral
+                  verilog-indent-level-declaration
+                  verilog-indent-level-module
+                  verilog-cexp-indent
+                  verilog-case-indent)
+    (web-mode web-mode-attr-indent-offset
+              web-mode-attr-value-indent-offset
+              web-mode-code-indent-offset
+              web-mode-css-indent-offset
+              web-mode-markup-indent-offset
+              web-mode-sql-indent-offset
+              web-mode-block-padding
+              web-mode-script-padding
+              web-mode-style-padding)
+    (yaml-mode yaml-indent-offset))
+  "Indentation retrieving variables matched to major modes used
+  when `doom-modeline-indent-info' is non-nil. When multiple
+  variables are specified for a mode, they will be tried resolved
+  in the given order."
+  :type '(alist :key-type symbol :value-type sexp)
+  :group 'doom-modeline)
+
 (defcustom doom-modeline-checker-simple-format t
   "If non-nil, only display one number for checker information if applicable."
   :type 'boolean

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -475,9 +475,21 @@ mouse-1: Previous buffer\nmouse-3: Next buffer"
 (doom-modeline-def-segment indent-info
   "Displays the indentation information."
   (when doom-modeline-indent-info
-    (propertize (format " %s %d "
-                        (if indent-tabs-mode "TAB" "SPC") tab-width)
-                'face (if (doom-modeline--active) 'mode-line 'mode-line-inactive))))
+    (let ((do-propertize
+           (lambda (mode size)
+             (propertize
+              (format " %s %d " mode size 'face
+                      (if (doom-modeline--active) 'mode-line 'mode-line-inactive))))))
+      (if indent-tabs-mode
+          (funcall do-propertize "TAB" tab-width)
+        (let ((lookup-var
+               (seq-find (lambda (var)
+                           (and var (boundp var) (symbol-value var)))
+                         (cdr (assoc major-mode doom-modeline-indent-alist)) nil)))
+          (funcall do-propertize "SPC"
+                   (if lookup-var
+                       (symbol-value lookup-var)
+                     tab-width)))))))
 
 ;;
 ;; Remote host


### PR DESCRIPTION
Instead of using `tab-width` for space indentation size, the correct indentation size variable is tried detected per major mode. If nothing can be found, it will fall back to `tab-width` as before.

It is based upon [`editorconfig-indentation-alist`](https://github.com/editorconfig/editorconfig-emacs/blob/master/editorconfig.el#L165) but is used to read indentation levels instead of setting them. When multiple variables are specified, they will be tried resolved in the given order.