### PR TITLE
Add option to show/hide workspace-name in modeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The `doom-modeline` was designed for minimalism, and offers:
 - A customizable mode-line height (see `doom-modeline-height`)
 - A minor modes segment which is compatible with `minions`
 - An error/warning count segment for `flymake`/`flycheck`
-- A workspace number segment for `eyebrowse`
+- A workspace number/name segment for `eyebrowse` or `tab-bar-mode`
 - A perspective name segment for `persp-mode`
 - A window number segment for `ace-window`, `winum` and `window-numbering`
 - An indicator for modal editing state, including `evil`, `overwrite`, `god`, `ryo` and
@@ -250,6 +250,9 @@ Run `M-x customize-group RET doom-modeline RET` or set the variables.
 
 ;; The maximum displayed length of the branch name of version control.
 (setq doom-modeline-vcs-max-length 12)
+
+;; Whether display the workspace name. Non-nil to display in the mode-line.
+(setq doom-modeline-workspace-name t)
 
 ;; Whether display the perspective name. Non-nil to display in the mode-line.
 (setq doom-modeline-persp-name t)

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -403,6 +403,13 @@ It respects `doom-modeline-enable-word-count'."
   :type 'integer
   :group 'doom-modeline)
 
+(defcustom doom-modeline-workspace-name t
+  "Whether display the workspace name.
+
+Non-nil to display in the mode-line."
+  :type 'boolean
+  :group 'doom-modeline)
+
 (defcustom doom-modeline-persp-name t
   "Whether display the perspective name.
 

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1435,25 +1435,26 @@ one. The ignored buffers are excluded unless `aw-ignore-on' is nil."
 (doom-modeline-def-segment workspace-name
   "The current workspace name or number.
 Requires `eyebrowse-mode' or `tab-bar-mode' to be enabled."
-  (when-let
-      ((name (cond
-              ((and (bound-and-true-p eyebrowse-mode)
-                    (< 1 (length (eyebrowse--get 'window-configs))))
-               (assq-delete-all 'eyebrowse-mode mode-line-misc-info)
-               (when-let*
-                   ((num (eyebrowse--get 'current-slot))
-                    (tag (nth 2 (assoc num (eyebrowse--get 'window-configs)))))
-                 (if (< 0 (length tag)) tag (int-to-string num))))
-              ((bound-and-true-p tab-bar-mode)
-               (let* ((current-tab (tab-bar--current-tab))
-                      (tab-index (tab-bar--current-tab-index))
-                      (explicit-name (alist-get 'explicit-name current-tab))
-                      (tab-name (alist-get 'name current-tab)))
-                 (if explicit-name tab-name (+ 1 tab-index)))))))
-    (propertize (format " %s " name) 'face
-                (if (doom-modeline--active)
-                    'doom-modeline-buffer-major-mode
-                  'mode-line-inactive))))
+  (when doom-modeline-workspace-name
+    (when-let
+        ((name (cond
+                ((and (bound-and-true-p eyebrowse-mode)
+                      (< 1 (length (eyebrowse--get 'window-configs))))
+                 (assq-delete-all 'eyebrowse-mode mode-line-misc-info)
+                 (when-let*
+                     ((num (eyebrowse--get 'current-slot))
+                      (tag (nth 2 (assoc num (eyebrowse--get 'window-configs)))))
+                   (if (< 0 (length tag)) tag (int-to-string num))))
+                ((bound-and-true-p tab-bar-mode)
+                 (let* ((current-tab (tab-bar--current-tab))
+                        (tab-index (tab-bar--current-tab-index))
+                        (explicit-name (alist-get 'explicit-name current-tab))
+                        (tab-name (alist-get 'name current-tab)))
+                   (if explicit-name tab-name (+ 1 tab-index)))))))
+      (propertize (format " %s " name) 'face
+                  (if (doom-modeline--active)
+                      'doom-modeline-buffer-major-mode
+                    'mode-line-inactive)))))
 
 
 ;;


### PR DESCRIPTION
I'm not sure if my "abuse" of the `when-let` to check the option is considered
good or bad in eslip, but seems to work. I'm happy to refactor though if it's
considered bad :)