### PR TITLE
Add support for Boon modal states

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1676,6 +1676,19 @@ TEXT is alternative if icon is not available."
                                  'doom-modeline-evil-normal-state
                                  (format "Xah-fly command mode")))))
 
+(defsubst doom-modeline--boon ()
+  "The current Boon state. Requires `boon-mode' to be enabled."
+  (when (bound-and-true-p boon-local-mode)
+    (doom-modeline--modal-icon
+     (boon-state-string)
+     (cond
+      (boon-command-state 'doom-modeline-evil-normal-state)
+      (boon-insert-state 'doom-modeline-evil-insert-state)
+      (boon-special-state 'doom-modeline-evil-emacs-state)
+      (boon-off-state 'doom-modeline-evil-operator-state)
+      (t 'doom-modeline-evil-operator-state))
+     (boon-modeline-string))))
+
 (doom-modeline-def-segment modals
   "Displays modal editing states, including `evil', `overwrite', `god', `ryo'
 and `xha-fly-kyes', etc."
@@ -1684,14 +1697,16 @@ and `xha-fly-kyes', etc."
          (god (doom-modeline--god))
          (ryo (doom-modeline--ryo))
          (xf (doom-modeline--xah-fly-keys))
+         (boon (doom-modeline--boon))
          (vsep (doom-modeline-vspc))
-         (sep (and (or evil ow god ryo xf) (doom-modeline-spc))))
+         (sep (and (or evil ow god ryo xf boon) (doom-modeline-spc))))
     (concat sep
-            (and evil (concat evil (and (or ow god ryo xf) vsep)))
-            (and ow (concat ow (and (or god ryo xf) vsep)))
-            (and god (concat god (and (or ryo xf) vsep)))
-            (and ryo (concat ryo (and xf vsep)))
-            xf
+            (and evil (concat evil (and (or ow god ryo xf boon) vsep)))
+            (and ow (concat ow (and (or god ryo xf boon) vsep)))
+            (and god (concat god (and (or ryo xf boon) vsep)))
+            (and ryo (concat ryo (and (or xf boon) vsep)))
+            (and xf (concat xf (and boon vsep)))
+            boon
             sep)))
 
 


### PR DESCRIPTION
[Boon](https://github.com/jyp/boon) is a modal mode for Emacs. This
commit adds support for Boon in the modal segment.

Boon has four states:
- Command (like Evil's normal)
- Insert
- Special (mostly pass-through, much like Evil's Emacs mode)
- Off, used when Boon really doesn't know what to do. There is no real
  equivalent in Evil; this commit uses the same face as Evil's
  operator state for this one. It's arbitrary, but it probably doesn't
  matter too much.