### PR TITLE
Add `pyenv version-name`

### DIFF
--- a/doom-modeline-env.el
+++ b/doom-modeline-env.el
@@ -196,17 +196,17 @@ PARSER should be a function for parsing COMMAND's output line-by-line, to
 (doom-modeline-def-env python
   :hooks   'python-mode-hook
   :command (lambda () (cond ((and (fboundp 'pipenv-project-p)
-                             (pipenv-project-p))
-                        (list "pipenv" "run"
-                              (or doom-modeline-env-python-executable
-                                  python-shell-interpreter
-                                  "python")
-                              "--version"))
-                       ((list (or doom-modeline-env-python-executable
-                                  python-shell-interpreter
-                                  "python")
-                              "--version"))))
-  :parser  (lambda (line) (cadr (split-string line))))
+                                  (pipenv-project-p))
+                             (list "pipenv" "run"))
+                            ((executable-find "pyenv") (list "pyenv" "version-name"))
+                            ((list (or doom-modeline-env-python-executable
+                                       python-shell-interpreter
+                                       "python")
+                                   "--version"))))
+  :parser  (lambda (line) (let ((version (split-string line)))
+                            (if (>= (length version) 2)
+                                (cadr version)
+                              (car version)))))
 
 ;;;###autoload (autoload 'doom-modeline-env-setup-ruby "doom-modeline-env")
 (doom-modeline-def-env ruby


### PR DESCRIPTION
The python environment will be shown in the following priority:

pipenv > pyenv > `doom-modeline-env-python-executable/python-shell-interpreter/python`