### PR TITLE
Add a "Now Playing" segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The `doom-modeline` was designed for minimalism, and offers:
 - An indicator for party `parrot`
 - An indicator for PDF page number with `pdf-tools`
 - An indicator for markdown/org preview with `grip`
+- The current "now playing" status for music/videos
 - Truncated file name, file icon, buffer state and project name in buffer
   information segment, which is compatible with `project`, `projectile` and
   `find-file-in-project`.

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -427,6 +427,28 @@ Non-nil to display in the mode-line."
   :type 'boolean
   :group 'doom-modeline)
 
+(defcustom doom-modeline-now-playing t
+  "Whether to display the `now-playing' state.
+
+Non-nil to display in the mode-line."
+  :type 'boolean
+  :group 'doom-modeline)
+
+(defcustom doom-modeline-now-playing-format "{{ artist}} - {{ title }}"
+  "Default output format for now-playing."
+  :type 'string
+  :group 'doom-modeline)
+
+(defcustom doom-modeline-now-playing-interval 5
+  "Default delay in seconds to run the update."
+  :type 'integer
+  :group 'doom-modeline)
+
+(defcustom doom-modeline-now-playing-ignored-players '("firefox")
+  "List of players to exclude from the command output."
+  :type '(repeat string)
+  :group 'doom-modeline)
+
 (defcustom doom-modeline-repl t
   "Whether display the `repl' state.
 
@@ -681,6 +703,21 @@ It requires `circe' or `erc' package."
 (defface doom-modeline-persp-buffer-not-in-persp
   '((t (:inherit (font-lock-doc-face bold italic))))
   "Face for the buffers which are not in the persp."
+  :group 'doom-modeline-faces)
+
+(defface doom-modeline-now-playing-success
+  '((t (:inherit success)))
+  "Face for the icon next to the status."
+  :group 'doom-modeline-faces)
+
+(defface doom-modeline-now-playing-other-icons
+  '((t (:inherit normal)))
+  "Face for the other icons."
+  :group 'doom-modeline-faces)
+
+(defface doom-modeline-now-playing-text
+  '((t (:inherit bold)))
+  "Face for the text of the now-playing text"
   :group 'doom-modeline-faces)
 
 (defface doom-modeline-repl-success

--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -91,7 +91,7 @@
 
 (doom-modeline-def-modeline 'main
   '(bar workspace-name window-number modals matches buffer-info remote-host buffer-position word-count parrot selection-info)
-  '(objed-state misc-info persp-name battery grip irc mu4e gnus github debug repl lsp minor-modes input-method indent-info buffer-encoding major-mode process vcs checker))
+  '(now-playing objed-state misc-info persp-name battery grip irc mu4e gnus github debug repl lsp minor-modes input-method indent-info buffer-encoding major-mode process vcs checker))
 
 (doom-modeline-def-modeline 'minimal
   '(bar matches buffer-info-simple)


### PR DESCRIPTION
Implement a segment for showing the current output of playerctl.

Uses the same logic as `github` to run the commands async and truncates if it's too long.

I welcome any criticism! :)

----

#