### PR TITLE
PDF Modeline Improvements

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -419,6 +419,12 @@ directory, the file name, and its state (modified, read-only or non-existent)."
 mouse-1: Previous buffer\nmouse-3: Next buffer"
                'local-map mode-line-buffer-identification-keymap)))
 
+(doom-modeline-def-segment buffer-name
+  "Display the current buffer's name, without any other information."
+  (concat
+   (doom-modeline-spc)
+   (doom-modeline--buffer-name)))
+
 (doom-modeline-def-segment buffer-default-directory
   "Displays `default-directory' with the icon and state . This is for special buffers
 like the scratch buffer where knowing the current project directory is important."
@@ -2221,19 +2227,34 @@ mouse-1: Toggle Debug on Quit"
 ;; PDF pages
 ;;
 
+(doom-modeline-def-segment pdf-icon
+  "PDF icon from all-the-icons."
+  (concat
+   (doom-modeline-spc)
+   (doom-modeline-icon 'octicon "file-pdf" nil nil
+                       :face (if (doom-modeline--active)
+                                 'all-the-icons-red
+                               'mode-line-inactive)
+                       :v-adjust 0.02)))
+
 (defvar-local doom-modeline--pdf-pages nil)
 (defun doom-modeline-update-pdf-pages ()
   "Update PDF pages."
   (setq doom-modeline--pdf-pages
-        (format "  P%d/%d "
-                (eval `(pdf-view-current-page))
-                (pdf-cache-number-of-pages))))
+        (let ((current-page-str (number-to-string (eval `(pdf-view-current-page))))
+              (total-page-str (number-to-string (pdf-cache-number-of-pages))))
+          (concat
+           (propertize
+            (concat (make-string (- (length total-page-str) (length current-page-str)) ? )
+                    " P" current-page-str)
+            'face 'mode-line)
+           (propertize (concat "/" total-page-str) 'face 'doom-modeline-buffer-minor-mode)))))
 (add-hook 'pdf-view-change-page-hook #'doom-modeline-update-pdf-pages)
 
 (doom-modeline-def-segment pdf-pages
   "Display PDF pages."
-  (propertize doom-modeline--pdf-pages
-              'face (if (doom-modeline--active) 'mode-line 'mode-line-inactive)))
+  (if (doom-modeline--active) doom-modeline--pdf-pages
+    (propertize doom-modeline--pdf-pages 'face 'mode-line-inactive)))
 
 
 ;;

--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -130,7 +130,7 @@
   '(objed-state misc-info battery debug minor-modes input-method indent-info buffer-encoding major-mode))
 
 (doom-modeline-def-modeline 'pdf
-  '(bar window-number matches buffer-info pdf-pages)
+  '(bar window-number matches pdf-pages pdf-icon buffer-name)
   '(misc-info major-mode process vcs))
 
 (doom-modeline-def-modeline 'org-src


### PR DESCRIPTION
There are a few changes here to improve the appearance of the PDF modeline.

- Prioritise the page information, move segment in front of buffer name
- Create (and use) new buffer-name segment, that doesn't include any
  mode or state information
- Left-pad `doom-modeline--pdf-pages` to ensure that for a given PDF
  it's always the same width
- Add a `pdf-icon` segment and place it in front of the buffer name