### PR TITLE
fix: typos in comments and docstrings

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -765,7 +765,7 @@ It requires `circe' or `erc' package."
 ;; Core helpers
 ;;
 
-;; FIXME #183: Force to caculate mode-line height
+;; FIXME #183: Force to calculate mode-line height
 ;; @see https://github.com/seagle0128/doom-modeline/issues/183
 (defvar-local doom-modeline--size-hacked-p nil)
 (defun doom-modeline-redisplay (&rest _)
@@ -784,7 +784,7 @@ is to make it easier to do so.
 This function is like `redisplay' with non-nil FORCE argument.
 It accepts an arbitrary number of arguments making it suitable
 as a `:before' advice for any function.  If the current buffer
-has no mode-line or this function has already been calle in it,
+has no mode-line or this function has already been called in it,
 then this function does nothing."
   (when (and (bound-and-true-p doom-modeline-mode)
              mode-line-format

--- a/doom-modeline-env.el
+++ b/doom-modeline-env.el
@@ -43,7 +43,7 @@
   :link '(url-link :tag "Homepage" "https://github.com/seagle0128/doom-modeline"))
 
 (defcustom doom-modeline-env-load-string "..."
-  "What to dispaly as the version while a new one is being loaded."
+  "What to display as the version while a new one is being loaded."
   :type 'string
   :group 'doom-modeline-env)
 
@@ -103,7 +103,7 @@ Example: 'doom-modeline-env--ruby")
 
 (defun doom-modeline-env--get (prog args callback)
   "Start a sub process using PROG and apply the ARGS to the sub process.
-Once it recieves information from STDOUT, it closes off the subprocess and
+Once it receives information from STDOUT, it closes off the subprocess and
 passes on the information into the CALLBACK.
 Example:
   (doom-modeline-env--get

--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -59,7 +59,7 @@
 ;; - An indicator for buffer position which is compatible with nyan-mode or poke-line
 ;; - An indicator for party parrot
 ;; - An indicator for PDF page number with pdf-tools
-;; - An indicator for markdown/org preivews with grip
+;; - An indicator for markdown/org previews with grip
 ;; - Truncated file name, file icon, buffer state and project name in buffer
 ;;   information segment, which is compatible with project, find-file-in-project
 ;;   and projectile
@@ -169,7 +169,7 @@ If DEFAULT is non-nil, set the default mode-line for all buffers."
 
 ;;;###autoload
 (defun doom-modeline-set-special-modeline ()
-  "Set sepcial mode-line."
+  "Set special mode-line."
   (doom-modeline-set-modeline 'special))
 
 ;;;###autoload


### PR DESCRIPTION
Hello.

Thanks for making this package.
I stumbled upon a few typos while skimming through the code.