### PR TITLE
Simplify image creation

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -1073,33 +1073,19 @@ ARGS is same as `all-the-icons-octicon' and others."
      ;; ASCII text
      (and text (propertize text 'face face)))))
 
-(defun doom-modeline--make-xpm (face width height)
-  "Create an XPM bitmap via FACE, WIDTH and HEIGHT. Inspired by `powerline''s `pl/make-xpm'."
+(defun doom-modeline--make-image (face width height)
+  "Create a PBM bitmap via FACE, WIDTH and HEIGHT."
   (when (and (display-graphic-p)
-             (image-type-available-p 'xpm))
+             (image-type-available-p 'pbm))
     (propertize
      " " 'display
-     (let ((data (make-list height (make-list width 1)))
-           (color (or (face-background face nil t) "None")))
+     (let ((color (or (face-background face nil t) "None")))
        (ignore-errors
          (create-image
-          (concat
-           (format
-            "/* XPM */\nstatic char * percent[] = {\n\"%i %i 2 1\",\n\". c %s\",\n\"  c %s\","
-            (length (car data)) (length data) color color)
-           (apply #'concat
-                  (cl-loop with idx = 0
-                           with len = (length data)
-                           for dl in data
-                           do (cl-incf idx)
-                           collect
-                           (concat
-                            "\""
-                            (cl-loop for d in dl
-                                     if (= d 0) collect (string-to-char " ")
-                                     else collect (string-to-char "."))
-                            (if (eq idx len) "\"};" "\",\n")))))
-  'xpm t :ascent 'center))))))
+          (concat (format "P1\n%i %i\n" width height)
+                  (make-string (* width height) ?1)
+                  "\n")
+          'pbm t :foreground color :ascent 'center))))))
 
 ;; Check whether `window-width' is smaller than the limit
 (defvar-local doom-modeline--limited-width-p nil)

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1359,9 +1359,9 @@ of active `multiple-cursors'."
                      (doom-modeline--font-height))))
     (when (and (numberp width) (numberp height))
       (setq doom-modeline--bar-active
-            (doom-modeline--make-xpm 'doom-modeline-bar width height)
+            (doom-modeline--make-image 'doom-modeline-bar width height)
             doom-modeline--bar-inactive
-            (doom-modeline--make-xpm 'doom-modeline-bar-inactive width height)))))
+            (doom-modeline--make-image 'doom-modeline-bar-inactive width height)))))
 
 (doom-modeline-add-variable-watcher
  'doom-modeline-height


### PR DESCRIPTION
Switch from an XPM to a PBM bitmap: PBM is easier to generate and easier
for Emacs to decode. Emacs has PBM support built-in so it's always
available (keep the `image-type-available-p` check in case this changes).

Stop creating a temporary list-of-lists to iterate over.

Rename `doom-modeline--make-xpm` to `doom-modeline--make-image` because
it's no longer creating an XPM, and the type of the bitmap should not
matter to callers.