### PR TITLE
Support hiding buffer encoding when at default

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -272,7 +272,21 @@ It respects `doom-modeline-enable-word-count'."
 
 (defcustom doom-modeline-buffer-encoding t
   "Whether display the buffer encoding."
-  :type 'boolean
+  :type '(choice (const :tag "Always" t)
+                 (const :tag "When non-default" nondefault)
+                 (const :tag "Never" nil))
+  :group 'doom-modeline)
+
+(defcustom doom-modeline-default-coding-system 'utf-8
+  "Default coding system for `doom-modeline-buffer-encoding' `nondefault'."
+  :type 'coding-system
+  :group 'doom-modeline)
+
+(defcustom doom-modeline-default-eol-type 0
+  "Default EOL type for `doom-modeline-buffer-encoding' `nondefault'."
+  :type '(choice (const :tag "Unix-style LF" 0)
+                 (const :tag "DOS-style CRLF" 1)
+                 (const :tag "Mac-style CR" 2))
   :group 'doom-modeline)
 
 (defcustom doom-modeline-indent-info nil


### PR DESCRIPTION
Only showing the buffer encoding and EOL style when they are
interesting (not at their default values) makes them stand out more when
needed, and frees up space when not. Users currently cannot hide the
coding-system and EOL segments separately, and would have to watch for
changes to `buffer-file-coding-system` to toggle visibility. Since
doom-modeline reads these values already anyway, we can easily add
support.

Add a new value `'nondefault` for `doom-modeline-buffer-encoding` to
enable this feature.

Add two new settings to set the default. Detecting the user's defaults
is tricky: Emacs does not use a single variable for the default coding
system but a prioritized list, and hooks can (and do, on Windows) change
the defaults. For now, hardcode reasonable "default defaults" and allow
the user to customize them.

Reorganize slightly to minimize work done if we choose not to display a
segment. Behavior when the new feature is not used should be unchanged.