### PR TITLE
Fix doom-modeline-env command to display python version under pipenv

### DIFF
--- a/doom-modeline-env.el
+++ b/doom-modeline-env.el
@@ -197,7 +197,11 @@ PARSER should be a function for parsing COMMAND's output line-by-line, to
   :hooks   'python-mode-hook
   :command (lambda () (cond ((and (fboundp 'pipenv-project-p)
                              (pipenv-project-p))
-                        (list "pipenv" "run"))
+                        (list "pipenv" "run"
+                              (or doom-modeline-env-python-executable
+                                  python-shell-interpreter
+                                  "python")
+                              "--version"))
                        ((executable-find "pyenv") (list "pyenv" "version-name"))
                        ((list (or doom-modeline-env-python-executable
                                   python-shell-interpreter


### PR DESCRIPTION
Thank you for your great work.
Let me give you a small patch for python version display.

This reverts "pipenv run python --version" command generation code
removed by #391 patch.

### Before This Change

<img width="858" alt="00_before-pipenv-python-ver" src="https://user-images.githubusercontent.com/12934757/116784124-7271a480-aacd-11eb-927b-a4c3524b51cb.png">

### After This Change

<img width="857" alt="01_after-pipenv-python-ver" src="https://user-images.githubusercontent.com/12934757/116784130-84534780-aacd-11eb-9445-c8806901fbcd.png">

### #391 degrade?

e898c0d master
doom-modeline-env.el (doom-modeline-def-env python ..)

```
(pipenv-project-p)
=> "~/"

doom-modeline-env-python-executable
=> "python"

python-shell-interpreter
=> "jupyter"

(funcall (lambda () (cond ((and (fboundp 'pipenv-project-p)
                             (pipenv-project-p))
                        (list "pipenv" "run"))
                       ((executable-find "pyenv") (list "pyenv" "version-name"))
                       ((list (or doom-modeline-env-python-executable
                                  python-shell-interpreter
                                  "python")
                              "--version")))))
=> ("pipenv" "run")
```

a73cc3d Rewrite env system
doom-modeline-env.el (doom-modeline-def-env python ..)

```
(pipenv-project-p)
=> "~/"

doom-modeline-env-python-executable
=> "python"

python-shell-interpreter
=> "jupyter"

(funcall (lambda () (cond ((and (fboundp 'pipenv-project-p)
                             (pipenv-project-p))
                        (list "pipenv" "run"
                              (or doom-modeline-env-python-executable
                                  python-shell-interpreter
                                  "python")
                              "--version"))
                       ((list (or doom-modeline-env-python-executable
                                  python-shell-interpreter
                                  "python")
                              "--version")))))
=> ("pipenv" "run" "python" "--version")
```
