### PR TITLE
Show tab-bar workspace-name even if tab-bar-show is nil

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1452,7 +1452,7 @@ one. The ignored buffers are excluded unless `aw-ignore-on' is nil."
 
 (doom-modeline-def-segment workspace-name
   "The current workspace name or number.
-Requires `eyebrowse-mode' or `tab-bar-mode' to be enabled."
+Requires `eyebrowse-mode' to be enabled or `tab-bar-mode' tabs to be created."
   (when doom-modeline-workspace-name
     (when-let
         ((name (cond
@@ -1463,7 +1463,8 @@ Requires `eyebrowse-mode' or `tab-bar-mode' to be enabled."
                      ((num (eyebrowse--get 'current-slot))
                       (tag (nth 2 (assoc num (eyebrowse--get 'window-configs)))))
                    (if (< 0 (length tag)) tag (int-to-string num))))
-                ((bound-and-true-p tab-bar-mode)
+                ((and (fboundp 'tab-bar-mode)
+                      (< 1 (length (frame-parameter nil 'tabs))))
                  (let* ((current-tab (tab-bar--current-tab))
                         (tab-index (tab-bar--current-tab-index))
                         (explicit-name (alist-get 'explicit-name current-tab))


### PR DESCRIPTION
Hello,
Let me give you a patch for workspace-name display.

Currently, tab-bar workspace-name is shown only if tab-bar-mode is not nil.

If tab-bar is hidden by setting tab-bar-show nil, tab-bar-mode is nil
but still new tabs can be created by tab-bar-new-tab.  Modeline
workspace-name should be displayed even if tab-bar is hidden.

In addition, after this change, workspace-name doesn't bother you
when tab-bar has only one tab.

## tab-bar-show

```elisp
(defcustom tab-bar-show t
  "Defines when to show the tab bar.
If t, enable `tab-bar-mode' automatically on using the commands that
create new window configurations (e.g. `tab-new').
If the value is `1', then hide the tab bar when it has only one tab,
and show it again once more tabs are created.
If nil, always keep the tab bar hidden.  In this case it's still
possible to use persistent named window configurations by relying on
keyboard commands `tab-new', `tab-close', `tab-next', `tab-switcher', etc."
  :type '(choice (const :tag "Always" t)
                 (const :tag "When more than one tab" 1)
                 (const :tag "Never" nil))
  :initialize 'custom-initialize-default
  :set (lambda (sym val)
         (set-default sym val)
         (tab-bar-mode
          (if (or (eq val t)
                  (and (natnump val)
                       (> (length (funcall tab-bar-tabs-function)) val)))
              1 -1)))
  :group 'tab-bar
  :version "27.1")
```

<img width="654" alt="workspace-name_tab-bar-show_nil" src="https://user-images.githubusercontent.com/12934757/117826594-3e576a00-b2ab-11eb-800b-aeceba6f0154.png">

## tab-bar is hidden -- (custom-set-variables '(tab-bar-show nil))

https://user-images.githubusercontent.com/12934757/117826680-50d1a380-b2ab-11eb-881f-78d2db195bc2.mov

## tab-bar is shown --  -- (custom-set-variables '(tab-bar-show t))

https://user-images.githubusercontent.com/12934757/117826709-562eee00-b2ab-11eb-932b-1cc07d2d0403.mov

