### PR TITLE
Fix void-function `doom-modeline--make-image`

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1365,9 +1365,9 @@ of active `multiple-cursors'."
                          (doom-modeline--font-height))))
         (when (and (numberp width) (numberp height))
           (setq doom-modeline--bar-active
-                (doom-modeline--make-image 'doom-modeline-bar width height)
+                (doom-modeline--create-bar-image 'doom-modeline-bar width height)
                 doom-modeline--bar-inactive
-                (doom-modeline--make-image
+                (doom-modeline--create-bar-image
                  'doom-modeline-bar-inactive width height)))))
     (if (doom-modeline--active)
         doom-modeline--bar-active


### PR DESCRIPTION
`doom-modeline--make-image` was replaced by
`doom-modeline--create-bar-image` but accidentally reverted in last
commit.