### PR TITLE
Option to have doom-modeline as a header instead

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -549,7 +549,6 @@ It requires `circe' or `erc' package."
   "If non-nil, displays the modeline in the header."
   :type 'boolean
   :group 'doom-modeline)
-
 
 ;;
 ;; Faces

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -545,6 +545,11 @@ It requires `circe' or `erc' package."
   :type 'function
   :group 'doom-modeline)
 
+(defcustom doom-modeline-header-line nil
+  "If non-nil, displays the modeline in the header."
+  :type 'boolean
+  :group 'doom-modeline)
+
 
 ;;
 ;; Faces
@@ -1017,8 +1022,11 @@ Throws an error if it doesn't exist."
 If DEFAULT is non-nil, set the default mode-line for all buffers."
   (when-let ((modeline (doom-modeline key)))
     (setf (if default
-              (default-value 'mode-line-format)
-            (buffer-local-value 'mode-line-format (current-buffer)))
+              (if doom-modeline-header-line (default-value 'header-line-format)
+                (default-value 'mode-line-format))
+            (if doom-modeline-header-line
+                (buffer-local-value 'header-line-format (current-buffer))
+                (buffer-local-value 'mode-line-format (current-buffer))))
           (list "%e" modeline))))
 
 

--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -262,6 +262,27 @@ So it can be restored when `doom-modeline-mode' is disabled.")
               (with-current-buffer bname
                 (doom-modeline-set-main-modeline))))
 
+        ;; Many themes do not set the header-line font correctly, this is just
+        ;; extra precaution
+        (when doom-modeline-header-line
+            (custom-set-faces
+             '(header-line ((t (:foreground nil :background nil :inherit mode-line))))
+             '(header-line-inactive ((t (:foreground nil :background nil :inherit mode-line-inactive))))
+             '(header-line-emphasis ((t (:foreground nil :bacground nil :inherit mode-line-emphasis))))))
+
+          ;(custom-set-faces   'header-line nil
+          ;                    :background (face-background 'mode-line)
+          ;                    :foreground (face-foreground 'mode-line)
+          ;                    :box (face-attribute 'mode-line :box)
+          ;(set-face-attribute 'header-line-inactive nil
+          ;                    :background (face-background 'mode-line-inactive)
+          ;                    :foreground (face-foreground 'mode-line-inactive)
+          ;                    :box (face-attribute 'mode-line :box))
+          ;(set-face-attribute 'header-line-emphasis nil
+          ;                    :foreground (face-foreground 'mode-line-emphasis)))))
+
+
+
         ;; For two-column editing
         (setq 2C-mode-line-format (doom-modeline 'special))
 
@@ -286,12 +307,17 @@ So it can be restored when `doom-modeline-mode' is disabled.")
         (advice-add #'helm-display-mode-line :after #'doom-modeline-set-helm-modeline))
     (progn
       ;; Restore mode-line
-      (setq mode-line-format doom-modeline--default-format)
-      (setq-default mode-line-format doom-modeline--default-format)
+      (if doom-modeline-header-line
+          (progn (setq header-line-format doom-modeline--default-format)
+                 (setq-default header-line-format doom-modeline--default-format))
+                (progn (setq mode-line-format doom-modeline--default-format)
+                       (setq-default mode-line-format doom-modeline--default-format)))
       (dolist (bname '("*scratch*" "*Messages*"))
         (if (buffer-live-p (get-buffer bname))
             (with-current-buffer bname
-              (setq mode-line-format doom-modeline--default-format))))
+              (if doom-modeline-header-line
+                  (setq header-line-format doom-modeline--default-format)
+                  (setq mode-line-format doom-modeline--default-format)))))
 
       ;; For two-column editing
       (setq 2C-mode-line-format

--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -270,19 +270,6 @@ So it can be restored when `doom-modeline-mode' is disabled.")
              '(header-line-inactive ((t (:foreground nil :background nil :inherit mode-line-inactive))))
              '(header-line-emphasis ((t (:foreground nil :bacground nil :inherit mode-line-emphasis))))))
 
-          ;(custom-set-faces   'header-line nil
-          ;                    :background (face-background 'mode-line)
-          ;                    :foreground (face-foreground 'mode-line)
-          ;                    :box (face-attribute 'mode-line :box)
-          ;(set-face-attribute 'header-line-inactive nil
-          ;                    :background (face-background 'mode-line-inactive)
-          ;                    :foreground (face-foreground 'mode-line-inactive)
-          ;                    :box (face-attribute 'mode-line :box))
-          ;(set-face-attribute 'header-line-emphasis nil
-          ;                    :foreground (face-foreground 'mode-line-emphasis)))))
-
-
-
         ;; For two-column editing
         (setq 2C-mode-line-format (doom-modeline 'special))
 


### PR DESCRIPTION
This pull-request implements the variable `doom-modeline-header-line`, which, if set to true, will put the modeline in the header instead. 

 
![image](https://user-images.githubusercontent.com/21983833/119656123-dad84b00-be19-11eb-995d-f4b06992a232.png)

Should mostly work in its current form.

Code is not the cleanest, Elisp is not my forte, but the general structure should be easily modifiable.
Note that this includes code to remap the header faces to the modeline faces, as they are usually not set (correctly) by most (doom-)themes. Ideally these would be implemented per theme, but this quick fix works. 

I did not check whether this works with all options, but there are /some/ bugs, namely that for some themes the unfocused version "dissappears". This can probably be fixed on a theme-by-theme basis, or possibly somewhere else, but for now I would not know how to fix this.

This (afaik) only affects the "doom-solarized-dark" theme
![image](https://user-images.githubusercontent.com/21983833/119654904-75378f00-be18-11eb-928c-74547d073556.png)


Let me know what you think! I will try to sort out some of the issues soon, but I can't promise when.