### PR TITLE
(De)Activate modeline for all existing buffers

### DIFF
--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -253,14 +253,12 @@ So it can be restored when `doom-modeline-mode' is disabled.")
   (if doom-modeline-mode
       (progn
         (doom-modeline-refresh-bars)        ; Create bars
-        (doom-modeline-set-main-modeline)   ; Set mode-line for current buffer
         (doom-modeline-set-main-modeline t) ; Set default mode-line
 
-        ;; These buffers are already created and don't get modelines
-        (dolist (bname '("*scratch*" "*Messages*"))
-          (if (buffer-live-p (get-buffer bname))
-              (with-current-buffer bname
-                (doom-modeline-set-main-modeline))))
+        ;; Apply to all existing buffers.
+        (dolist (buf (buffer-list))
+          (with-current-buffer buf
+            (doom-modeline-set-main-modeline)))
 
         ;; For two-column editing
         (setq 2C-mode-line-format (doom-modeline 'special))
@@ -286,12 +284,10 @@ So it can be restored when `doom-modeline-mode' is disabled.")
         (advice-add #'helm-display-mode-line :after #'doom-modeline-set-helm-modeline))
     (progn
       ;; Restore mode-line
-      (setq mode-line-format doom-modeline--default-format)
       (setq-default mode-line-format doom-modeline--default-format)
-      (dolist (bname '("*scratch*" "*Messages*"))
-        (if (buffer-live-p (get-buffer bname))
-            (with-current-buffer bname
-              (setq mode-line-format doom-modeline--default-format))))
+      (dolist (buf (buffer-list))
+        (with-current-buffer buf
+          (setq mode-line-format doom-modeline--default-format)))
 
       ;; For two-column editing
       (setq 2C-mode-line-format


### PR DESCRIPTION
Instead of (de)activating the modeline for the current buffer and a couple of special-cased buffers, (de)activate it for all open buffers. This:

1. Ensures that enabling/disabling the modeline at any point sets the modeline everywhere.
2. We actually catch all buffers at start, regardless of startup order. Without this patch, the "*Async-native-compile-log*" doesn't get a modeline.