### PR TITLE
Use `file-local-name` to get VC state

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -650,7 +650,7 @@ Uses `all-the-icons-octicon' to fetch the icon."
   (setq doom-modeline--vcs-icon
         (when (and vc-mode buffer-file-name)
           (let* ((backend (vc-backend buffer-file-name))
-                 (state   (vc-state buffer-file-name backend)))
+                 (state   (vc-state (file-local-name buffer-file-name) backend)))
             (cond ((memq state '(edited added))
                    (doom-modeline-vcs-icon "git-compare" "⇆" "*" 'doom-modeline-info -0.05))
                   ((eq state 'needs-merge)
@@ -689,7 +689,7 @@ Uses `all-the-icons-octicon' to fetch the icon."
   (setq doom-modeline--vcs-text
         (when (and vc-mode buffer-file-name)
           (let* ((backend (vc-backend buffer-file-name))
-                 (state (vc-state buffer-file-name backend))
+                 (state (vc-state (file-local-name buffer-file-name) backend))
                  (str (if vc-display-status
                           (substring vc-mode (+ (if (eq backend 'Hg) 2 3) 2))
                         "")))


### PR DESCRIPTION
Recently the [change in vc-git in emacs](https://github.com/emacs-mirror/emacs/commit/3572613550f5d1d0b3392dbc809b32f3989e2981)
broke modeline state in remote files as it prepends a string in the
beginning and cannot retrieve relative file path to pass as git command
argument.

The fix here ensures that the prefix in the beginning of the file path
doesn't break the `(vc-state)` command by passing local file name of the
remote files.

Fix #463