### PR TITLE
Improve force redisplay advice

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -146,10 +146,8 @@ It returns a file name which can be used directly as argument of
 
 (defcustom doom-modeline-height 25
   "How tall the mode-line should be. It's only respected in GUI.
-If the actual char height is larger, it respects the actual char
-height.  If `doom-modeline-height' is <= 0 and
-`doom-modeline-icon' is nil, a simpler modeline with default
-height and no icons will be created."
+If the actual char height is larger, it respects the actual char height.
+If `doom-modeline-height' is <= 0 the modeline will have default height."
   :type 'integer
   :group 'doom-modeline)
 
@@ -232,9 +230,7 @@ Given ~/Projects/FOSS/emacs/lisp/comint.el
 (defcustom doom-modeline-icon t
   "Whether display the icons in the mode-line.
 
-While using the server mode in GUI, should set the value explicitly.
-If it is nil and `doom-modeline-height' is <= 0, a simpler modeline
-with default height and no icons will be created."
+While using the server mode in GUI, should set the value explicitly."
   :type 'boolean
   :group 'doom-modeline)
 
@@ -1043,8 +1039,7 @@ If DEFAULT is non-nil, set the default mode-line for all buffers."
     ;; WORKAROUND: Fix tall issue of 27 on Linux
     ;; @see https://github.com/seagle0128/doom-modeline/issues/271
     (round
-     (* (if (or (and (<= doom-modeline-height 0)
-                     (not doom-modeline-icon))
+     (* (if (or (<= doom-modeline-height 0)
                 (and (>= emacs-major-version 27)
                      (not (eq system-type 'darwin))))
             1.0


### PR DESCRIPTION
Fixes #483 and #480. Also fixes the problem with `org-attach` described in https://github.com/tarsius/moody/issues/34.

By unconditionally advising `split-window` we ensure that redisplay:

1. Always triggers in the right window, so it solves an issue with `org-attach` calling `fit-window-to-buffer` from a different window.

2. It's not tied to a buffer that may outlive its popup, so it solves the issue with `org-set-tags-command` which buffer kept lurking around with `doom-modeline--size-hacked-p` set to t.

As all known workarounds, this will trigger a quick sequence redisplay -> fit -> redisplay that causes some little flickering when the window effectively changes size in-between (which is usually the case with popups).

Moreover, `fit-window-to-buffer` always transforms a height in pixels to a height in characters and this operation unavoidably rounds up to the next integer height in characters when the mode-line is of a different size than the default character, hence introducing some small amount of padding at the bottom of the window.

In order to avoid small but yet unpleasant visual artifacts whenever possible, we only trigger a redisplay when it is strictly required, that is when the mode-line height effectively differs from the default character height.

To facilitate the construction of a "vanilla height" modeline, when `doom-modeline-height` <= 0 and `doom-modeline-icon` is nil we ensure that this simpler modeline will be created, no matter the platform.