### PR TITLE
Add modeline segment for follow-mode

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -2915,6 +2915,21 @@ mouse-3: Restart preview"
                                 map)))
      (doom-modeline-spc))))
 
+;;
+;; Follow mode
+;;
+
+(doom-modeline-def-segment follow
+  (when (bound-and-true-p follow-mode)
+    (let* ((windows (follow-all-followers))
+           (nwindows (length windows))
+           (nfollowing (- (length (memq (selected-window) windows))
+                          1)))
+      (concat
+       (doom-modeline-spc)
+       (propertize (format "Follow %d/%d" (- nwindows nfollowing) nwindows)
+                   'face 'doom-modeline-buffer-minor-mode)))))
+
 (provide 'doom-modeline-segments)
 
 ;;; doom-modeline-segments.el ends here

--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -90,7 +90,7 @@
 ;;
 
 (doom-modeline-def-modeline 'main
-  '(bar workspace-name window-number modals matches buffer-info remote-host buffer-position word-count parrot selection-info)
+  '(bar workspace-name window-number modals matches follow buffer-info remote-host buffer-position word-count parrot selection-info)
   '(objed-state misc-info persp-name battery grip irc mu4e gnus github debug repl lsp minor-modes input-method indent-info buffer-encoding major-mode process vcs checker))
 
 (doom-modeline-def-modeline 'minimal


### PR DESCRIPTION
When follow-mode is enabled for a buffer, this will show a segment left
of buffer-info (which contains the file name) like "Follow M/N", where N
is the total number of follow windows for this buffer and M is the index
of the selected window.