### PR TITLE
changed 'xah-fly-insert-state-q' to 'xah-fly-insert-state-p'

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -102,7 +102,7 @@
 (defvar text-scale-mode-amount)
 (defvar tracking-buffers)
 (defvar winum-auto-setup-mode-line)
-(defvar xah-fly-insert-state-q)
+(defvar xah-fly-insert-state-p)
 
 (declare-function anzu--reset-status 'anzu)
 (declare-function anzu--where-is-here 'anzu)
@@ -1781,7 +1781,7 @@ TEXT is alternative if icon is not available."
 (defsubst doom-modeline--xah-fly-keys ()
   "The current `xah-fly-keys' state."
   (when (bound-and-true-p xah-fly-keys)
-    (if xah-fly-insert-state-q
+    (if xah-fly-insert-state-p
         (doom-modeline--modal-icon " <I> "
                                    'doom-modeline-evil-insert-state
                                    (format "Xah-fly insert mode"))


### PR DESCRIPTION
The variable signaling the current mode state changed in Nov. 2021 at this commit:
https://github.com/xahlee/xah-fly-keys/commit/c6a7367afa0dbdb734319268f4e0bb708f4fec11#diff-0e4ccd274fc24cf949be60a562eec725e12c88f11eb005c6821c9fd0fe03aba2

This renaming fixes it.