### PR TITLE
Ensure compatibility with newer project.el

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -1176,7 +1176,7 @@ Return nil if no project was found."
                (projectile-project-root))
               ('project
                (when-let ((project (project-current)))
-                 (expand-file-name (cdr project))))))))
+                 (expand-file-name (project-root project))))))))
 
 (defun doom-modeline-project-p ()
   "Check if the file is in a project."


### PR DESCRIPTION
As of
https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=86969f9658,
the return value of project-current is shaped differently.