### PR TITLE
Actually account for stale versions of project.el

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -1176,7 +1176,9 @@ Return nil if no project was found."
                (projectile-project-root))
               ('project
                (when-let ((project (project-current)))
-                 (expand-file-name (project-root project))))))))
+                 (expand-file-name (if (fboundp 'project-root)
+                                       (project-root project)
+                                     (cdr project)))))))))
 
 (defun doom-modeline-project-p ()
   "Check if the file is in a project."

--- a/test/doom-modeline-core-test.el
+++ b/test/doom-modeline-core-test.el
@@ -67,9 +67,15 @@
   (let ((default-directory "/home/user/project/")
         (doom-modeline-project-detection 'auto)
         (doom-modeline--project-root nil))
-    (cl-flet ((project-current (&optional _maybe-prompt _dir)
-                               `(vc . ,default-directory)))
-      (should (string= (doom-modeline-project-root) default-directory)))))
+    (should (string= (doom-modeline-project-root) default-directory))))
+
+(ert-deftest doom-modeline-project-root/auto-old ()
+  ;; Old versions of project.el do not have `project-root'
+  (skip-unless (< emacs-major-version 26))
+  (let ((default-directory "/home/user/project-current/")
+        (doom-modeline-project-detection 'auto)
+        (doom-modeline--project-root nil))
+    (should (string= (doom-modeline-project-root) default-directory))))
 
 (ert-deftest doom-modeline-project-root/ffip ()
   (let ((default-directory "/home/user/project-ffip/")
@@ -86,12 +92,20 @@
       (should (string= (doom-modeline-project-root) default-directory)))))
 
 (ert-deftest doom-modeline-project-root/project ()
+  ;; The latest `project' requires Emacs >= 26.1
+  (skip-unless (>= emacs-major-version 26))
   (let ((default-directory "/home/user/project-current/")
         (doom-modeline-project-detection 'project)
         (doom-modeline--project-root nil))
-    (cl-flet ((project-current (&optional _maybe-prompt _dir)
-                               `(vc . ,default-directory)))
-      (should (string= (doom-modeline-project-root) default-directory)))))
+    (should (string= (doom-modeline-project-root) default-directory))))
+
+(ert-deftest doom-modeline-project-root/project-old ()
+  ;; Old versions of project.el do not have `project-root'
+  (skip-unless (< emacs-major-version 26))
+  (let ((default-directory "/home/user/project-current/")
+        (doom-modeline-project-detection 'project)
+        (doom-modeline--project-root nil))
+    (should (string= (doom-modeline-project-root) default-directory))))
 
 (ert-deftest doom-modeline-project-root/default ()
   (let ((default-directory "/home/user/project/")


### PR DESCRIPTION
The project.el shipped with Emacsen <= 27 do not actually have
`project-root` at all. We account for this by restoring the old
behavior of doom-modeline--project-root in an else branch.

Since the testing suite installs a recent
project.el on Emacsen >= 26, test the old behavior only on Emacsen <
26. 