### PR TITLE
Fix warnings about single quotes in docstrings

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -1070,10 +1070,10 @@ LHS and RHS are lists of symbols of modeline segments defined with
 `doom-modeline-def-segment'.
 
 Example:
-  (doom-modeline-def-modeline 'minimal
-    '(bar matches \" \" buffer-info)
-    '(media-info major-mode))
-  (doom-modeline-set-modeline 'minimal t)"
+  (doom-modeline-def-modeline \\='minimal
+    \\='(bar matches \" \" buffer-info)
+    \\='(media-info major-mode))
+  (doom-modeline-set-modeline \\='minimal t)"
   (let ((sym (intern (format "doom-modeline-format--%s" name)))
         (lhs-forms (doom-modeline--prepare-segments lhs))
         (rhs-forms (doom-modeline--prepare-segments rhs)))

--- a/doom-modeline-env.el
+++ b/doom-modeline-env.el
@@ -69,11 +69,11 @@ Example: \"ruby\"")
 
 (defvar-local doom-modeline-env--command-args nil
   "A list of arguments for the command to extract the version from.
-Example: '(\"--version\") ")
+Example: \\='(\"--version\") ")
 
 (defvar-local doom-modeline-env--parser nil
   "A function that returns version number from a command --version (or similar).
-Example: 'doom-modeline-env--ruby")
+Example: \\='doom-modeline-env--ruby")
 
 
 ;; Functions & Macros
@@ -115,7 +115,7 @@ passes on the information into the CALLBACK.
 Example:
   (doom-modeline-env--get
      \"ruby\"
-     '(\"--version\")
+     \\='(\"--version\")
      (lambda (line)
         (message (doom-modeline-parser--ruby line)))"
   (let ((proc (apply 'start-process

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -2164,8 +2164,8 @@ mouse-1: Toggle citre mode"
 (defvar doom-modeline-before-github-fetch-notification-hook nil
   "Hooks before fetching GitHub notifications.
 Example:
-  (add-hook 'doom-modeline-before-github-fetch-notification-hook
-            #'auth-source-pass-enable)")
+  (add-hook \\='doom-modeline-before-github-fetch-notification-hook
+            #\\='auth-source-pass-enable)")
 (defun doom-modeline--github-fetch-notifications ()
   "Fetch GitHub notifications."
   (when (and doom-modeline-github


### PR DESCRIPTION
* doom-modeline-core.el (doom-modeline-def-modeline):
* doom-modeline-env.el (doom-modeline-env--command-args)
(doom-modeline-env--parser, doom-modeline-env--get):
* doom-modeline-segments.el
(doom-modeline-before-github-fetch-notification-hook): Fix
warnings about wrong usage of unescaped single quotes in
docstrings issued by Emacs 29.