### PR TITLE
add doom modeline support for display-time-mode

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -754,6 +754,10 @@ Also see the face `doom-modeline-unread-number'."
   "Face for timemachine status."
   :group 'doom-modeline-faces)
 
+(defface doom-modeline-date
+  '((t (:inherit (mode-line-buffer-id bold))))
+  "Face for display time."
+  :group 'doom-modeline-faces)
 
 ;;
 ;; Externals
@@ -955,6 +959,11 @@ If FRAME is nil, it means the current frame."
             ((error "%s is not a valid segment" seg))))
     (nreverse forms)))
 
+(defvar doom-modeline--date-not-removed-p t)
+(defun doom-modeline--display-time-clean ()
+  "remove display-time string in misc-info"
+  (setq global-mode-string (delete 'display-time-string global-mode-string)))
+
 (defun doom-modeline-def-modeline (name lhs &optional rhs)
   "Define a modeline format and byte-compiles it.
 NAME is a symbol to identify it (used by `doom-modeline' for retrieval).
@@ -966,6 +975,11 @@ Example:
     \\='(bar matches \" \" buffer-info)
     \\='(media-info major-mode))
   (doom-modeline-set-modeline \\='minimal t)"
+  (when (and doom-modeline--date-not-removed-p
+             (or (member 'date lhs) (member 'date rhs)))
+    (add-hook 'display-time-hook #'doom-modeline--display-time-clean t t)
+    (setq doom-modeline--date-not-removed-p nil))
+
   (let ((sym (intern (format "doom-modeline-format--%s" name)))
         (lhs-forms (doom-modeline--prepare-segments lhs))
         (rhs-forms (doom-modeline--prepare-segments rhs)))

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -959,11 +959,6 @@ If FRAME is nil, it means the current frame."
             ((error "%s is not a valid segment" seg))))
     (nreverse forms)))
 
-(defvar doom-modeline--date-not-removed-p t)
-(defun doom-modeline--display-time-clean ()
-  "remove display-time string in misc-info"
-  (setq global-mode-string (delete 'display-time-string global-mode-string)))
-
 (defun doom-modeline-def-modeline (name lhs &optional rhs)
   "Define a modeline format and byte-compiles it.
 NAME is a symbol to identify it (used by `doom-modeline' for retrieval).
@@ -975,11 +970,6 @@ Example:
     \\='(bar matches \" \" buffer-info)
     \\='(media-info major-mode))
   (doom-modeline-set-modeline \\='minimal t)"
-  (when (and doom-modeline--date-not-removed-p
-             (or (member 'date lhs) (member 'date rhs)))
-    (add-hook 'display-time-hook #'doom-modeline--display-time-clean t t)
-    (setq doom-modeline--date-not-removed-p nil))
-
   (let ((sym (intern (format "doom-modeline-format--%s" name)))
         (lhs-forms (doom-modeline--prepare-segments lhs))
         (rhs-forms (doom-modeline--prepare-segments rhs)))

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -2940,15 +2940,21 @@ mouse-3: Restart preview"
   (when (bound-and-true-p display-time-mode)
     (propertize
      (concat
-      (when doom-modeline-icon
-        doom-modeline-spc
-        (doom-modeline-icon 'faicon  "calendar" "📅" ""
-                            :face 'doom-modeline-date
-                            :height 1.2 :v-adjust -0.0575))
+      (doom-modeline-icon 'faicon  "calendar" "📅" ""
+                          :face 'doom-modeline-date
+                          :height 1.2 :v-adjust -0.0575)
       doom-modeline-spc
       (format "%s" display-time-string)
       doom-modeline-spc)
      'face (doom-modeline-face 'doom-modeline-date))))
+
+(defun doom-modeline-override-display-time-modeline ()
+  "Override default display-time mode-line."
+  (if (bound-and-true-p doom-modeline-mode)
+      (setq global-mode-string (delq 'display-time-string global-mode-string))
+    (setq global-mode-string (append global-mode-string '(display-time-string)))))
+(add-hook 'display-time-mode-hook #'doom-modeline-override-display-time-modeline)
+(add-hook 'doom-modeline-mode-hook #'doom-modeline-override-display-time-modeline)
 
 (provide 'doom-modeline-segments)
 

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -104,6 +104,7 @@
 (defvar tracking-buffers)
 (defvar winum-auto-setup-mode-line)
 (defvar xah-fly-insert-state-p)
+(defvar display-time-string)
 
 (declare-function all-the-icons-icon-for-buffer "ext:all-the-icons")
 (declare-function anzu--reset-status "ext:anzu")
@@ -2933,6 +2934,21 @@ mouse-3: Restart preview"
        doom-modeline-spc
        (propertize (format "Follow %d/%d" (- nwindows nfollowing) nwindows)
                    'face 'doom-modeline-buffer-minor-mode)))))
+
+(doom-modeline-def-segment date
+  "date"
+  (when (bound-and-true-p display-time-mode)
+    (propertize
+     (concat
+      (when doom-modeline-icon
+        doom-modeline-spc
+        (doom-modeline-icon 'faicon  "calendar" "📅" ""
+                            :face 'doom-modeline-date
+                            :height 1.2 :v-adjust -0.0575))
+      doom-modeline-spc
+      (format "%s" display-time-string)
+      doom-modeline-spc)
+     'face (doom-modeline-face 'doom-modeline-date))))
 
 (provide 'doom-modeline-segments)
 

--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -89,59 +89,59 @@
 
 (doom-modeline-def-modeline 'main
   '(bar workspace-name window-number modals matches follow buffer-info remote-host buffer-position word-count parrot selection-info)
-  '(objed-state misc-info persp-name battery grip irc mu4e gnus github debug repl lsp minor-modes input-method indent-info buffer-encoding major-mode process vcs checker))
+  '(objed-state misc-info persp-name battery grip irc mu4e gnus github debug repl lsp minor-modes input-method indent-info buffer-encoding major-mode process vcs checker date))
 
 (doom-modeline-def-modeline 'minimal
   '(bar matches buffer-info-simple)
-  '(media-info major-mode))
+  '(media-info major-mode date))
 
 (doom-modeline-def-modeline 'special
   '(bar window-number modals matches buffer-info buffer-position word-count parrot selection-info)
-  '(objed-state misc-info battery irc-buffers debug minor-modes input-method indent-info buffer-encoding major-mode process))
+  '(objed-state misc-info battery irc-buffers debug minor-modes input-method indent-info buffer-encoding major-mode process date))
 
 (doom-modeline-def-modeline 'project
   '(bar window-number modals buffer-default-directory)
-  '(misc-info battery irc mu4e gnus github debug minor-modes input-method major-mode process))
+  '(misc-info battery irc mu4e gnus github debug minor-modes input-method major-mode process date))
 
 (doom-modeline-def-modeline 'dashboard
   '(bar window-number buffer-default-directory-simple)
-  '(misc-info battery irc mu4e gnus github debug minor-modes input-method major-mode process))
+  '(misc-info battery irc mu4e gnus github debug minor-modes input-method major-mode process date))
 
 (doom-modeline-def-modeline 'vcs
   '(bar window-number modals matches buffer-info buffer-position parrot selection-info)
-  '(misc-info battery irc mu4e gnus github debug minor-modes buffer-encoding major-mode process))
+  '(misc-info battery irc mu4e gnus github debug minor-modes buffer-encoding major-mode process date))
 
 (doom-modeline-def-modeline 'package
   '(bar window-number package)
-  '(misc-info major-mode process))
+  '(misc-info major-mode process date))
 
 (doom-modeline-def-modeline 'info
   '(bar window-number buffer-info info-nodes buffer-position parrot selection-info)
-  '(misc-info buffer-encoding major-mode))
+  '(misc-info buffer-encoding major-mode date))
 
 (doom-modeline-def-modeline 'media
   '(bar window-number buffer-size buffer-info)
-  '(misc-info media-info major-mode process vcs))
+  '(misc-info media-info major-mode process vcs date))
 
 (doom-modeline-def-modeline 'message
   '(bar window-number modals matches buffer-info-simple buffer-position word-count parrot selection-info)
-  '(objed-state misc-info battery debug minor-modes input-method indent-info buffer-encoding major-mode))
+  '(objed-state misc-info battery debug minor-modes input-method indent-info buffer-encoding major-mode date))
 
 (doom-modeline-def-modeline 'pdf
   '(bar window-number matches buffer-info pdf-pages)
-  '(misc-info major-mode process vcs))
+  '(misc-info major-mode process vcs date))
 
 (doom-modeline-def-modeline 'org-src
   '(bar window-number modals matches buffer-info-simple buffer-position word-count parrot selection-info)
-  '(objed-state misc-info debug lsp minor-modes input-method indent-info buffer-encoding major-mode process checker))
+  '(objed-state misc-info debug lsp minor-modes input-method indent-info buffer-encoding major-mode process checker date))
 
 (doom-modeline-def-modeline 'helm
   '(bar helm-buffer-id helm-number helm-follow helm-prefix-argument)
-  '(helm-help))
+  '(helm-help date))
 
 (doom-modeline-def-modeline 'timemachine
   '(bar window-number modals matches git-timemachine buffer-position word-count parrot selection-info)
-  '(misc-info minor-modes indent-info buffer-encoding major-mode))
+  '(misc-info minor-modes indent-info buffer-encoding major-mode date))
 
 
 ;;


### PR DESCRIPTION
增加doom-modeline 对于 display-time-mode 的原生支持以取代原来的misc-info中自带的`display-time-string`。以下是效果图：

![image](https://user-images.githubusercontent.com/28672146/180780443-a1e89fb5-2eb5-446d-a313-89e68a9ceaa1.png)
