### PR TITLE
[Feature] New option doom-modeline-display-misc-in-all-mode-lines

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -529,6 +529,13 @@ It respects `display-time-mode'."
   :type 'boolean
   :group 'doom-modeline)
 
+(defcustom doom-modeline-display-misc-in-all-mode-lines t
+  "Whether display the misc segment on all mode lines.
+
+If nil, display only if the mode line is active."
+  :type 'boolean
+  :group 'doom-modeline)
+
 
 ;;
 ;; Faces

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1612,7 +1612,9 @@ mouse-2: Show help for minor mode"
 (doom-modeline-def-segment misc-info
   "Mode line construct for miscellaneous information.
 By default, this shows the information specified by `global-mode-string'."
-  (unless doom-modeline--limited-width-p
+  (when (and (not doom-modeline--limited-width-p)
+             (or doom-modeline-display-misc-in-all-mode-lines
+                 (doom-modeline--active)))
     '("" mode-line-misc-info)))
 
 


### PR DESCRIPTION
Hello,

I've added an option to reverse the change in https://github.com/seagle0128/doom-modeline/commit/81666b9b142d091a46d19e43ce08061b9dca973b.

I think it's a reasonable request to hide the misc segment if the modeline is inactive. For instance, perspective.el adds its segment there, which is enough to show only once on a particular frame.