### PR TITLE
Tweak flycheck segment running/finished icons

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -771,12 +771,12 @@ level."
                 ('finished  (if flycheck-current-errors
                                 (let-alist (doom-modeline--flycheck-count-errors)
                                   (doom-modeline-checker-icon
-                                   "block" "🚫" "!"
+                                   "error_outline" "🚫" "!"
                                    (cond ((> .error 0) 'doom-modeline-urgent)
                                          ((> .warning 0) 'doom-modeline-warning)
                                          (t 'doom-modeline-info))))
                               (doom-modeline-checker-icon "check" "✓" "-" 'doom-modeline-info)))
-                ('running     (doom-modeline-checker-icon "access_time" "⏱" "*" 'doom-modeline-debug))
+                ('running     (doom-modeline-checker-icon "update" "⏳" "*" 'doom-modeline-debug))
                 ('no-checker  (doom-modeline-checker-icon "sim_card_alert" "⚠" "-" 'doom-modeline-debug))
                 ('errored     (doom-modeline-checker-icon "sim_card_alert" "⚠" "-" 'doom-modeline-urgent))
                 ('interrupted (doom-modeline-checker-icon "pause" "⏸" "=" 'doom-modeline-debug))


### PR DESCRIPTION
I found myself not-entirely-happy with the current set of flycheck status icons, so I asked around and presented a few alternatives. In the end it seems there's a near-consensus among the ~half dozen people who responded that the change in this PR is an improvement over the current state of affairs.

Here are some comparison screenshots, and some relevant quotes from the discussion.

### Flycheck running

**Current**

![image](https://user-images.githubusercontent.com/20903656/191298866-aea98746-4f2c-4afc-90f3-cb591e3aa4d7.png)

**Consensus improvement**

![image](https://user-images.githubusercontent.com/20903656/191298934-73e22a63-5feb-4cb4-b91b-676fc965dd88.png)

**Quotes from the discussion**

> Hourglass means 'background process happening' to me
> I'd probably stick with the hourglass for the win3.1 nostalgia
> favourites for processing: hourglass

### Flycheck results

**Current**

![image](https://user-images.githubusercontent.com/20903656/191299155-5fda7b21-4393-42ab-8e2f-f9d429f35f69.png)

**Consensus improvement**

![image](https://user-images.githubusercontent.com/20903656/191299199-eb88bc77-6138-4786-97f7-9ee9f2905236.png)

**Quotes from the discussion**

> (4 upvotes on this image, all the rest received 0)
> favourite for errors: exclamation-mark-in-a-circle (the other ones mean forbidden)