### PR TITLE
Update the buffer name when the current Info node changes

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -335,6 +335,7 @@ Uses `all-the-icons-material' to fetch the icon."
 (add-hook 'after-save-hook #'doom-modeline-update-buffer-file-name)
 (add-hook 'clone-indirect-buffer-hook #'doom-modeline-update-buffer-file-name)
 (add-hook 'evil-insert-state-exit-hook #'doom-modeline-update-buffer-file-name)
+(add-hook 'Info-selection-hook #'doom-modeline-update-buffer-file-name)
 (advice-add #'not-modified :after #'doom-modeline-update-buffer-file-name)
 (advice-add #'rename-buffer :after #'doom-modeline-update-buffer-file-name)
 (advice-add #'set-visited-file-name :after #'doom-modeline-update-buffer-file-name)


### PR DESCRIPTION
Without this patch only the name of first the visited node when `(info)` is invoked will be displayed in the modeline. When further info nodes are navigated the buffer name in the modeline remains the same, hence showing wrong information.