### PR TITLE
Use unspecified instead of nil in `defface'

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -571,7 +571,7 @@ If nil, display only if the mode line is active."
   :group 'doom-modeline-faces)
 
 (defface doom-modeline-buffer-modified
-  '((t (:inherit (error bold) :background nil)))
+  '((t (:inherit (error bold) :background unspecified)))
   "Face used for the \\='unsaved\\=' symbol in the mode-line."
   :group 'doom-modeline-faces)
 


### PR DESCRIPTION
* doom-modeline-core.el (doom-modeline-buffer-modified): Fix warning about setting attribute `:background' to nil value is invalid.