### PR TITLE
Fix: doom-modeline-modal-icon nil condition

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1742,7 +1742,8 @@ mouse-1: Display Line and Column Mode Menu"
 TEXT is alternative if icon is not available."
   (propertize (doom-modeline-icon
                'material
-               (or icon "fiber_manual_record")
+               (when doom-modeline-modal-icon
+                 (or icon "fiber_manual_record"))
                (or unicode "●")
                text
                :face (doom-modeline-face face)


### PR DESCRIPTION
commit https://github.com/seagle0128/doom-modeline/commit/5d9c20aed929398d79cf847c2d7b14b0bfe3cb99 break `doom-modeline-modal-icon` `nil` condition.
