### PR TITLE
Fix boon mode-line segment

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1812,8 +1812,8 @@ TEXT is alternative if icon is not available."
       (boon-special-state 'doom-modeline-boon-special-state)
       (boon-off-state 'doom-modeline-boon-off-state)
       (t 'doom-modeline-boon-off-state))
-     (boon-modeline-string))
-    "local_cafe" "🍵"))
+     (boon-modeline-string)
+     "local_cafe" "🍵")))
 
 (defsubst doom-modeline--meow ()
   "The current Meow state. Requires `meow-mode' to be enabled."


### PR DESCRIPTION
The `ICON` and `UNICODE` arguments were outside of `doom-modeline--boon`, so `when` always returned "🍵".