### PR TITLE
Make buffer-modified face inherit from warning

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -582,7 +582,7 @@ inactive windows."
   :group 'doom-modeline-faces)
 
 (defface doom-modeline-buffer-modified
-  '((t (:inherit (error bold) :background unspecified)))
+  '((t (:inherit (warning bold) :background unspecified)))
   "Face used for the \\='unsaved\\=' symbol in the mode-line."
   :group 'doom-modeline-faces)
 


### PR DESCRIPTION
Error signals that there's something terribly wrong, and while you should probably *save* that modified buffer, warning styling seems like a much more appropriate indication of concern.

For reference, I have overridden this in my own config, and I've seen one or two people in the Doom discord confused and thinking that there was something wrong because the file name had gone error-red in the modelling. I doubt this is a common issue, but it helps confirm in my mind that this is a worthwhile QoL change.