### PR TITLE
Improve doom-modeline-def-modeline

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -1076,23 +1076,25 @@ Example:
         (rhs-forms (doom-modeline--prepare-segments rhs)))
     (defalias sym
       (lambda ()
-        (list lhs-forms
-              (propertize
-               " "
-               'display `(space
-                          :align-to
-                          (- (+ right right-fringe right-margin scroll-bar)
-                             ,(let ((rhs-str (format-mode-line (cons "" rhs-forms))))
-                                (if (and (>= emacs-major-version 29)
-                                         (fboundp 'string-pixel-width))
-                                    (/ (string-pixel-width rhs-str)
-                                       (doom-modeline--font-width)
-                                       1.0)
-                                  (* (string-width rhs-str)
-                                     (if (display-graphic-p)
-                                         (/ (doom-modeline--font-width) (frame-char-width) 0.95)
-                                       1.0)))))))
-              rhs-forms))
+        (if rhs-forms
+            (let ((rhs-str (format-mode-line (cons "" rhs-forms))))
+              (list lhs-forms
+                    (propertize
+                     " "
+                     'display `(space
+                                :align-to
+                                (- (+ right right-fringe right-margin scroll-bar)
+                                   ,(if (and (>= emacs-major-version 29)
+                                             (fboundp 'string-pixel-width))
+                                        (/ (string-pixel-width rhs-str)
+                                           (doom-modeline--font-width)
+                                           1.0)
+                                      (* (string-width rhs-str)
+                                         (if (display-graphic-p)
+                                             (/ (doom-modeline--font-width) (frame-char-width) 0.95)
+                                           1.0))))))
+                    rhs-str))
+          lhs-forms))
       (concat "Modeline:\n"
               (format "  %s\n  %s"
                       (prin1-to-string lhs)


### PR DESCRIPTION
To calculate the alightment of rhs, rhs was formated but its result was thrown
away resulting rhs to be unnecessary formated twice. Improved by using the
formted rhs-str. Also avoid unnecessary calculatin when rhs-form is nil.