### PR TITLE
Should not hard-truncate vc-mode text

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -709,9 +709,7 @@ Uses `all-the-icons-octicon' to fetch the icon."
         (when (and vc-mode buffer-file-name)
           (let* ((backend (vc-backend buffer-file-name))
                  (state (vc-state (file-local-name buffer-file-name) backend))
-                 (str (if vc-display-status
-                          (substring vc-mode (+ (if (eq backend 'Hg) 2 3) 2))
-                        "")))
+                 (str (if vc-display-status vc-mode "")))
             (propertize (if (length> str doom-modeline-vcs-max-length)
                             (concat
                              (substring str 0 (- doom-modeline-vcs-max-length 3))


### PR DESCRIPTION
Hi,

In function `doom-modeline-update-vcs-text`, I think that the truncation of `vc-mode` text is supposed to be controlled by the variable `doom-modeline-vcs-max-length`.

```emacs-lisp
(defun doom-modeline-update-vcs-text (&rest _)
  "Update text of vcs state in mode-line."
  (setq doom-modeline--vcs-text
        (when (and vc-mode buffer-file-name)
          (let* ((backend (vc-backend buffer-file-name))
                 (state (vc-state (file-local-name buffer-file-name) backend))
                 (str (if vc-display-status
                          (substring vc-mode (+ (if (eq backend 'Hg) 2 3) 2))
                        "")))
            (propertize (if (length> str doom-modeline-vcs-max-length)
                            (concat
                             (substring str 0 (- doom-modeline-vcs-max-length 3))
                             doom-modeline-ellipsis)
                          str)
                        'mouse-face 'doom-modeline-highlight
                        'face (cond ((eq state 'needs-update)
                                     'doom-modeline-warning)
                                    ((memq state '(removed conflict unregistered))
                                     'doom-modeline-urgent)
                                    (t 'doom-modeline-info)))))))
```

But somehow, `vc-mode` is hard-truncated earlier, before where `doom-modeline-vcs-max-length` is checked.

```emacs-lisp
                 (str (if vc-display-status
                          (substring vc-mode (+ (if (eq backend 'Hg) 2 3) 2))
                        ""))
```

So, I created this PR to remove the hard-truncation `(substring vc-mode (+ (if (eq backend 'Hg) 2 3) 2))`.

Can you review if it can be merged?

Thanks!