### PR TITLE
Pacify the compiler

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -157,7 +157,6 @@ Given ~/Projects/FOSS/emacs/lisp/comint.el
   buffer-name => comint.el<2> (uniquify buffer name)"
   :type '(choice (const auto)
                  (const truncate-upto-project)
-                 (const truncate-upto-project)
                  (const truncate-from-project)
                  (const truncate-with-project)
                  (const truncate-except-project)


### PR DESCRIPTION
* doom-modeline-core.el (doom-modeline-buffer-file-name-style): Delete duplicate entry for `truncate-upto-project'.