### PR TITLE
Add support for updating forge notifications when the counter changes

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -510,6 +510,15 @@ It requires `ghub' and `async' packages."
   :type 'integer
   :group 'doom-modeline)
 
+(defcustom doom-modeline-github-update-forge nil
+  "Whether to update the GitHub notifications in `forge'.
+
+When both this variable and `doom-modeline-github' are non-nil,
+`forge-pull-notifications' will run every time the notification count is
+updated."
+  :type 'boolean
+  :group 'doom-modeline)
+
 (defcustom doom-modeline-env-version t
   "Whether display the environment version."
   :type 'boolean

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -2235,7 +2235,12 @@ Example:
                           :noerror t))))))
      (lambda (result)
        (message "")                     ; suppress message
-       (setq doom-modeline--github-notification-number (length result))))))
+       (let ((count (length result)))
+	 (when (and (featurep 'forge)
+		    doom-modeline-github-update-forge
+		    (not (eq doom-modeline--github-notification-number count)))
+	   (forge-pull-notifications))
+	 (setq doom-modeline--github-notification-number count))))))
 
 (defvar doom-modeline--github-timer nil)
 (defun doom-modeline-github-timer ()


### PR DESCRIPTION
I’m not sure if there is interest in this functionality, but I thought it could be useful for those who use [forge](https://github.com/magit/forge) to check GitHub notifications. It modifies `doom-modeline--github-fetch-notifications` and adds a user option, `doom-modeline-github-update-forge`, such that when its value is non-nil, an update to `doom-modeline--github-notification-number` will trigger the fetching of notifications in forge.

I’m relatively new to programming and Elisp specifically, so feel free to reject or suggest revisions.