### PR TITLE
Fix python version with direnv

### DIFF
--- a/doom-modeline-env.el
+++ b/doom-modeline-env.el
@@ -216,7 +216,7 @@ PARSER should be a function for parsing COMMAND's output line-by-line, to
                                    "-c"
                                    ;; Direnv unfortunately writes crao on stderr
                                    ;; so we need to pipe that to /dev/null
-                                   (format "'direnv exec %s %s --version 2>/dev/null'"
+                                   (format "direnv exec %s %s --version 2>/dev/null"
                                            default-directory
                                            (or doom-modeline-env-python-executable
                                                python-shell-interpreter


### PR DESCRIPTION
When using `direnv`, the word "line" is displayed instead of python version as we can see in this screenshot
![Capture d’écran du 2023-12-11 20-18-30](https://github.com/seagle0128/doom-modeline/assets/17704127/5ae9bb70-2def-42e8-a806-7ed8fbb39975)

The problem comes from using single quotes in addition to double quotes in the command used to detect python. We can reproduce the problem in a terminal : 
![Capture d’écran du 2023-12-11 20-25-38](https://github.com/seagle0128/doom-modeline/assets/17704127/ba1acbd2-c163-4a7d-9da6-702b7b5e0ecc)

