### PR TITLE
fix: use jsonrpc-continuation-count in doom-modeline-update-eglot

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -2069,14 +2069,19 @@ mouse-1: Reload to start server")
 (add-hook 'lsp-before-open-hook #'doom-modeline-update-lsp)
 (add-hook 'lsp-after-open-hook #'doom-modeline-update-lsp)
 
+(defun doom-modeline--eglot-pending-count (server)
+  "Get count of pending eglot requests to SERVER."
+  (if (fboundp 'jsonrpc-continuation-count)
+      (jsonrpc-continuation-count server)
+    (hash-table-count (jsonrpc--request-continuations server))))
+
 (defvar-local doom-modeline--eglot nil)
 (defun doom-modeline-update-eglot ()
   "Update `eglot' state."
   (setq doom-modeline--eglot
         (pcase-let* ((server (and (eglot-managed-p) (eglot-current-server)))
                      (nick (and server (eglot--project-nickname server)))
-                     (pending (and server (hash-table-count
-                                           (jsonrpc--request-continuations server))))
+                     (pending (and server (doom-modeline--eglot-pending-count server)))
                      (last-error (and server (jsonrpc-last-error server)))
                      (face (cond (last-error 'doom-modeline-lsp-error)
                                  ((and pending (cl-plusp pending)) 'doom-modeline-lsp-warning)


### PR DESCRIPTION
Jsonrpc continuations were reworked on the Emacs master branch to be an alist rather than a hash-table in commit [222f563f136](https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=222f563f136c5cb106df1fb94c177fe24c83683f). 

Currently, this change breaks `doom-modeline-update-eglot`, which prevents `eglot` from starting due to a type error from the use of `hash-table-count` on an alist.  The function `jsonrpc-continuation-count` was added to properly get the number of continuations. 

This PR adds a function `doom-modeline--eglot-pending-count` to check if the new function is bound, and if not, fallback to the old method of getting the pending count.
