### PR TITLE
Fix call of `define-obsolete-variable-alias'

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -445,15 +445,15 @@ in the given order."
   :type '(alist :key-type symbol :value-type sexp)
   :group 'doom-modeline)
 
-(defcustom doom-modeline-check-simple-format t
-  "If non-nil, only display one number for check information if applicable."
-  :type 'boolean
-  :group 'doom-modeline)
-
 (define-obsolete-variable-alias
   'doom-modeline-checker-simple-format
   'doom-modeline-check-simple-format
   "4.2.0")
+
+(defcustom doom-modeline-check-simple-format t
+  "If non-nil, only display one number for check information if applicable."
+  :type 'boolean
+  :group 'doom-modeline)
 
 (defcustom doom-modeline-number-limit 99
   "The maximum number displayed for notifications."


### PR DESCRIPTION
* doom-modeline-core.el (doom-modeline-check-simple-format): Move `defcustom' after the `define-obsolete-variable-alias' form.  From the docstring:

If CURRENT-NAME is a defcustom or a defvar (more generally, any variable where OBSOLETE-NAME may be set, e.g. in an init file, before the alias is defined), then the
define-obsolete-variable-alias statement should be evaluated before the defcustom, if user customizations are to be respected.