### PR TITLE
Introduce analogue clock time icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,10 @@ Run `M-x customize-group RET doom-modeline RET` or set the variables.
 ;; It respects option `doom-modeline-icon' and option `doom-modeline-time-icon'.
 (setq doom-modeline-time-live-icon t)
 
+;; Whether to use an analogue clock svg as the live time icon.
+;; It respects options `doom-modeline-icon', `doom-modeline-time-icon', and `doom-modeline-time-live-icon'.
+(setq doom-modeline-time-analogue-clock t)
+
 ;; Whether to use unicode as a fallback (instead of ASCII) when not using icons.
 (setq doom-modeline-unicode-fallback nil)
 

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -233,6 +233,20 @@ It respects option `doom-modeline-icon' and option `doom-modeline-time-icon'."
   :type 'boolean
   :group 'doom-modeline)
 
+(defcustom doom-modeline-time-analogue-clock t
+  "Whether to draw an analogue clock SVG as the live time icon.
+
+It respects options `doom-modeline-icon', `doom-modeline-time-icon', and
+`doom-modeline-time-live-icon'."
+  :type 'boolean
+  :group 'doom-modeline)
+
+(defcustom doom-modeline-time-clock-minute-resolution 1
+  "The clock will be updated every this many minutes, truncated.
+See `doom-modeline-time-analogue-clock'."
+  :type 'number
+  :group 'doom-modeline)
+
 (defcustom doom-modeline-unicode-fallback nil
   "Whether to use unicode as a fallback (instead of ASCII) when not using icons."
   :type 'boolean


### PR DESCRIPTION
With the SVG library (bundled as part of Emacs), we can generate an analogue clock for the current time to-the-minute, instead of using the nearest-hour nerdicon.

I've personally been running this variant of the time segment since https://github.com/seagle0128/doom-modeline/issues/577#issuecomment-1267020963, and so am pretty confident this works as we'd hope.

The one thing I wonder about is whether we can make the `svg` library be required only when `doom-modeline--generate-clock` is first called?

Sample screenshot:
![image](https://github.com/seagle0128/doom-modeline/assets/20903656/603dc547-2451-40ca-9d38-f362190ea70c)
