### PR TITLE
Correct typos in docstrings

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -252,7 +252,7 @@ An integer value is used as the diameter of clock in pixels.
 A floating point value sets the diameter of the clock realtive to
 `doom-modeline-height'.
 
-Only relevant when `doom-modeline-time-analogue-clock' is non-nill, which see."
+Only relevant when `doom-modeline-time-analogue-clock' is non-nil, which see."
   :type 'number
   :group 'doom-modeline)
 

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -3114,7 +3114,7 @@ The clock will be of the specified RADIUS and COLOR."
 
 (defun doom-modeline--generate-clock ()
   "Return a string containing the current time as an analogue clock svg.
-When the svg library is not availible, return nil."
+When the svg library is not available, return nil."
   (cdr
    (or (and (equal (truncate (float-time)
                              (* doom-modeline-time-clock-minute-resolution 60))


### PR DESCRIPTION
* doom-modeline-core.el (doom-modeline-time-clock-size):
* doom-modeline-segments.el (doom-modeline--generate-clock): Fix typos introduced in commit 311a0c5.