### PR TITLE
Add support for display icons in check-simple-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,12 @@ Run `M-x customize-group RET doom-modeline RET` or set the variables.
 ;; If set to icons, display check information with icons.
 (setq doom-modeline-check-simple-format t)
 
+;; Change error icons.
+;; Only if doom-modeline-check-simple-format is set to icons
+(setq doom-modeline-check-error-icon "⛔")
+(setq doom-modeline-check-warning-icon "❌")
+(setq doom-modeline-check-note-icon "❎")
+
 ;; The maximum number displayed for notifications.
 (setq doom-modeline-number-limit 99)
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Run `M-x customize-group RET doom-modeline RET` or set the variables.
 (setq doom-modeline-total-line-number nil)
 
 ;; If non-nil, only display one number for check information if applicable.
+;; If set to icons, display check information with icons.
 (setq doom-modeline-check-simple-format t)
 
 ;; The maximum number displayed for notifications.

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -474,7 +474,8 @@ in the given order."
   "4.2.0")
 
 (defcustom doom-modeline-check-simple-format t
-  "If non-nil, only display one number for check information if applicable."
+  "If non-nil, only display one number for check information if applicable.
+If set to icons, display check information with icons."
   :type '(choice boolean
                  (const :tag "simple icons" icons))
   :group 'doom-modeline)

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -480,22 +480,6 @@ If set to icons, display check information with icons."
                  (const :tag "simple icons" icons))
   :group 'doom-modeline)
 
-(defcustom doom-modeline-check-warning-icon
-  (doom-modeline-check-icon
-   "nf-md-alert_outline" "⚠" "!" 'doom-modeline-warning)
-  "Icon to be using in check segment.
-Only works if `doom-modeline-check-simple-format' is set to icons."
-  :type '(string)
-  :group 'doom-modeline)
-
-(defcustom doom-modeline-check-note-icon
-  (doom-modeline-check-icon
-   "nf-md-information_outline" "i" "i" 'doom-modeline-info)
-  "Icon to be using in check segment.
-Only works if `doom-modeline-check-simple-format' is set to icons."
-  :type '(string)
-  :group 'doom-modeline)
-
 (defcustom doom-modeline-number-limit 99
   "The maximum number displayed for notifications."
   :type 'integer

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -475,7 +475,24 @@ in the given order."
 
 (defcustom doom-modeline-check-simple-format t
   "If non-nil, only display one number for check information if applicable."
-  :type 'boolean
+  :type '(choice boolean
+                 (const :tag "simple icons" icons))
+  :group 'doom-modeline)
+
+(defcustom doom-modeline-check-warning-icon
+  (doom-modeline-check-icon
+   "nf-md-alert_outline" "⚠" "!" 'doom-modeline-warning)
+  "Icon to be using in check segment.
+Only works if `doom-modeline-check-simple-format' is set to icons."
+  :type '(string)
+  :group 'doom-modeline)
+
+(defcustom doom-modeline-check-note-icon
+  (doom-modeline-check-icon
+   "nf-md-information_outline" "i" "i" 'doom-modeline-info)
+  "Icon to be using in check segment.
+Only works if `doom-modeline-check-simple-format' is set to icons."
+  :type '(string)
   :group 'doom-modeline)
 
 (defcustom doom-modeline-number-limit 99

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -109,6 +109,30 @@
 (defvar winum-auto-setup-mode-line)
 (defvar xah-fly-insert-state-p)
 
+(defcustom doom-modeline-check-error-icon
+  (doom-modeline-check-icon
+   "nf-md-alert_circle_outline" "❗" "!" 'doom-modeline-urgent)
+  "Icon to be using in check segment.
+Only works if `doom-modeline-check-simple-format' is set to icons."
+  :type '(string)
+  :group 'doom-modeline)
+
+(defcustom doom-modeline-check-warning-icon
+  (doom-modeline-check-icon
+   "nf-md-alert_outline" "⚠" "!" 'doom-modeline-warning)
+  "Icon to be using in check segment.
+Only works if `doom-modeline-check-simple-format' is set to icons."
+  :type '(string)
+  :group 'doom-modeline)
+
+(defcustom doom-modeline-check-note-icon
+  (doom-modeline-check-icon
+   "nf-md-information_outline" "❔" "i" 'doom-modeline-info)
+  "Icon to be using in check segment.
+Only works if `doom-modeline-check-simple-format' is set to icons."
+  :type '(string)
+  :group 'doom-modeline)
+
 (declare-function anzu--reset-status "ext:anzu")
 (declare-function anzu--where-is-here "ext:anzu")
 (declare-function async-inject-variables "ext:async")
@@ -789,8 +813,7 @@ level."
      				     (cond ((> .error 0) 'doom-modeline-urgent)
            				    ((> .warning 0) 'doom-modeline-warning)
            				    (t 'doom-modeline-info)))
-  				  (doom-modeline-check-icon "nf-md-alert_circle_outline" "❗" "!"
-					  'doom-modeline-urgent)))
+  				  doom-modeline-check-error-icon))
                               (doom-modeline-check-icon "nf-md-check_circle_outline" "✔" "" 'doom-modeline-info)))
                 ('running     (doom-modeline-check-icon "nf-md-timer_sand" "⏳" "*" 'doom-modeline-debug))
                 ('no-checker  (doom-modeline-check-icon "nf-md-alert_box_outline" "⚠" "-" 'doom-modeline-debug))

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -862,7 +862,7 @@ mouse-2: Show help for minor mode")
                                                                           'doom-modeline-warning)
                                                 (doom-modeline-check-text (number-to-string .info)
                                                                           'doom-modeline-info)))
-                                  ('icons (format "%s %s%s %s%s"
+                                  ('icons (format "%s %s %s %s %s"
                                                   (doom-modeline-check-text (number-to-string .error)
                                                                             'doom-modeline-urgent)
                                                   doom-modeline-check-warning-icon
@@ -1065,7 +1065,7 @@ mouse-2: Show help for minor mode"
                                                                   'doom-modeline-warning)
                                         (doom-modeline-check-text (number-to-string .note)
                                                                   'doom-modeline-info)))
-                          ('icons (format "%s %s%s %s%s"
+                          ('icons (format "%s %s %s %s %s"
                                           (doom-modeline-check-text (number-to-string .error)
                                                                     'doom-modeline-urgent)
                                           doom-modeline-check-warning-icon

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -865,12 +865,10 @@ mouse-2: Show help for minor mode")
                                   ('icons (format "%s %s%s %s%s"
                                                   (doom-modeline-check-text (number-to-string .error)
                                                                             'doom-modeline-urgent)
-                                                  (doom-modeline-check-text doom-modeline-check-warning-icon
-                                                                            'doom-modeline-warning)
+                                                  doom-modeline-check-warning-icon
                                                   (doom-modeline-check-text (number-to-string .warning)
                                                                             'doom-modeline-warning)
-                                                  (doom-modeline-check-text doom-modeline-check-note-icon
-                                                                            'doom-modeline-info)
+                                                  doom-modeline-check-note-icon
                                                   (doom-modeline-check-text (number-to-string .info)
                                                                             'doom-modeline-info)))))))
                 ('running     (and doom-modeline--flycheck-text
@@ -1070,12 +1068,10 @@ mouse-2: Show help for minor mode"
                           ('icons (format "%s %s%s %s%s"
                                           (doom-modeline-check-text (number-to-string .error)
                                                                     'doom-modeline-urgent)
-                                          (doom-modeline-check-text doom-modeline-check-warning-icon
-                                                                    'doom-modeline-warning)
+                                          doom-modeline-check-warning-icon
                                           (doom-modeline-check-text (number-to-string .warning)
                                                                     'doom-modeline-warning)
-                                          (doom-modeline-check-text doom-modeline-check-note-icon
-                                                                    'doom-modeline-info)
+                                          doom-modeline-check-note-icon
                                           (doom-modeline-check-text (number-to-string .note)
                                                                     'doom-modeline-info))))))))))
             (propertize

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -898,20 +898,20 @@ mouse-3: Next error"
            'mouse-face 'doom-modeline-highlight
            'local-map (let ((map (make-sparse-keymap)))
                         (define-key map [mode-line mouse-1]
-                                    #'flycheck-list-errors)
+                          #'flycheck-list-errors)
                         (define-key map [mode-line mouse-3]
-                                    #'flycheck-next-error)
+                          #'flycheck-next-error)
                         (when (doom-modeline-mwheel-available-p)
                           (define-key map [mode-line mouse-wheel-down-event]
-                                      (lambda (event)
-                                        (interactive "e")
-                                        (with-selected-window (posn-window (event-start event))
-                                          (flycheck-previous-error 1))))
+                            (lambda (event)
+                              (interactive "e")
+                              (with-selected-window (posn-window (event-start event))
+                                (flycheck-previous-error 1))))
                           (define-key map [mode-line mouse-wheel-up-event]
-                                      (lambda (event)
-                                        (interactive "e")
-                                        (with-selected-window (posn-window (event-start event))
-                                          (flycheck-next-error 1))))
+                            (lambda (event)
+                              (interactive "e")
+                              (with-selected-window (posn-window (event-start event))
+                                (flycheck-next-error 1))))
                           map))))))
 (add-hook 'flycheck-status-changed-functions #'doom-modeline-update-flycheck-text)
 (add-hook 'flycheck-mode-hook #'doom-modeline-update-flycheck-text)

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -783,11 +783,14 @@ level."
               (pcase status
                 ('finished  (if flycheck-current-errors
                                 (let-alist (doom-modeline--flycheck-count-errors)
-                                  (doom-modeline-check-icon
-                                   "nf-md-alert_circle_outline" "❗" "!"
-                                   (cond ((> .error 0) 'doom-modeline-urgent)
-                                         ((> .warning 0) 'doom-modeline-warning)
-                                         (t 'doom-modeline-info))))
+				(if (not (eq doom-modeline-check-simple-format 'icons))
+    				    (doom-modeline-check-icon
+				     "nf-md-alert_circle_outline" "❗" "!"
+     				     (cond ((> .error 0) 'doom-modeline-urgent)
+           				    ((> .warning 0) 'doom-modeline-warning)
+           				    (t 'doom-modeline-info)))
+  				  (doom-modeline-check-icon "nf-md-alert_circle_outline" "❗" "!"
+					  'doom-modeline-urgent)))
                               (doom-modeline-check-icon "nf-md-check_circle_outline" "✔" "" 'doom-modeline-info)))
                 ('running     (doom-modeline-check-icon "nf-md-timer_sand" "⏳" "*" 'doom-modeline-debug))
                 ('no-checker  (doom-modeline-check-icon "nf-md-alert_box_outline" "⚠" "-" 'doom-modeline-debug))
@@ -846,19 +849,30 @@ mouse-2: Show help for minor mode")
               (pcase status
                 ('finished  (when flycheck-current-errors
                               (let-alist (doom-modeline--flycheck-count-errors)
-                                (if doom-modeline-check-simple-format
-                                    (doom-modeline-check-text
-                                     (number-to-string (+ .error .warning .info))
-                                     (cond ((> .error 0) 'doom-modeline-urgent)
-                                           ((> .warning 0) 'doom-modeline-warning)
-                                           (t 'doom-modeline-info)))
-                                  (format "%s/%s/%s"
-                                          (doom-modeline-check-text (number-to-string .error)
-                                                                      'doom-modeline-urgent)
-                                          (doom-modeline-check-text (number-to-string .warning)
-                                                                      'doom-modeline-warning)
-                                          (doom-modeline-check-text (number-to-string .info)
-                                                                      'doom-modeline-info))))))
+                                (pcase doom-modeline-check-simple-format
+                                  ('t (doom-modeline-check-text
+                                       (number-to-string (+ .error .warning .info))
+                                       (cond ((> .error 0) 'doom-modeline-urgent)
+                                             ((> .warning 0) 'doom-modeline-warning)
+                                             (t 'doom-modeline-info))))
+                                  ('nil (format "%s/%s/%s"
+                                                (doom-modeline-check-text (number-to-string .error)
+                                                                          'doom-modeline-urgent)
+                                                (doom-modeline-check-text (number-to-string .warning)
+                                                                          'doom-modeline-warning)
+                                                (doom-modeline-check-text (number-to-string .info)
+                                                                          'doom-modeline-info)))
+                                  ('icons (format "%s %s%s %s%s"
+                                                  (doom-modeline-check-text (number-to-string .error)
+                                                                            'doom-modeline-urgent)
+                                                  (doom-modeline-check-text doom-modeline-check-warning-icon
+                                                                            'doom-modeline-warning)
+                                                  (doom-modeline-check-text (number-to-string .warning)
+                                                                            'doom-modeline-warning)
+                                                  (doom-modeline-check-text doom-modeline-check-note-icon
+                                                                            'doom-modeline-info)
+                                                  (doom-modeline-check-text (number-to-string .info)
+                                                                            'doom-modeline-info)))))))
                 ('running     (and doom-modeline--flycheck-text
                                    (propertize doom-modeline--flycheck-text 'face 'doom-modeline-debug)))
                 ;; ('no-checker  nil)
@@ -886,20 +900,20 @@ mouse-3: Next error"
            'mouse-face 'doom-modeline-highlight
            'local-map (let ((map (make-sparse-keymap)))
                         (define-key map [mode-line mouse-1]
-                          #'flycheck-list-errors)
+                                    #'flycheck-list-errors)
                         (define-key map [mode-line mouse-3]
-                          #'flycheck-next-error)
+                                    #'flycheck-next-error)
                         (when (doom-modeline-mwheel-available-p)
                           (define-key map [mode-line mouse-wheel-down-event]
-                            (lambda (event)
-                              (interactive "e")
-                              (with-selected-window (posn-window (event-start event))
-                                (flycheck-previous-error 1))))
+                                      (lambda (event)
+                                        (interactive "e")
+                                        (with-selected-window (posn-window (event-start event))
+                                          (flycheck-previous-error 1))))
                           (define-key map [mode-line mouse-wheel-up-event]
-                            (lambda (event)
-                              (interactive "e")
-                              (with-selected-window (posn-window (event-start event))
-                                (flycheck-next-error 1))))
+                                      (lambda (event)
+                                        (interactive "e")
+                                        (with-selected-window (posn-window (event-start event))
+                                          (flycheck-next-error 1))))
                           map))))))
 (add-hook 'flycheck-status-changed-functions #'doom-modeline-update-flycheck-text)
 (add-hook 'flycheck-mode-hook #'doom-modeline-update-flycheck-text)
@@ -958,10 +972,12 @@ mouse-3: Next error"
                                      ((> severity note-level)    (cl-incf .warning))
                                      (t                          (cl-incf .note))))))
                         (if (> (+ .error .warning .note) 0)
-                            (doom-modeline-check-icon "nf-md-alert_circle_outline" "❗" "!"
-                                                        (cond ((> .error 0) 'doom-modeline-urgent)
-                                                              ((> .warning 0) 'doom-modeline-warning)
-                                                              (t 'doom-modeline-info)))
+			    (if (not (eq doom-modeline-check-simple-format 'icons))
+			       (doom-modeline-check-icon "nf-md-alert_circle_outline" "❗" "!"
+                                                          (cond ((> .error 0) 'doom-modeline-urgent)
+                                                                ((> .warning 0) 'doom-modeline-warning)
+                                                                (t 'doom-modeline-info)))
+			      (doom-modeline-check-icon "nf-md-alert_circle_outline" "❗" "!" 'doom-modeline-urgent))
                           (doom-modeline-check-icon "nf-md-check_circle_outline" "✔" "-" 'doom-modeline-info))))))))
             (propertize
              icon
@@ -1039,18 +1055,29 @@ mouse-2: Show help for minor mode"
                  (all-disabled nil)
                  (t (let ((num (+ .error .warning .note)))
                       (when (> num 0)
-                        (if doom-modeline-check-simple-format
-                            (doom-modeline-check-text (number-to-string num)
+                        (pcase doom-modeline-check-simple-format
+                          ('t (doom-modeline-check-text (number-to-string num)
                                                         (cond ((> .error 0) 'doom-modeline-urgent)
                                                               ((> .warning 0) 'doom-modeline-warning)
-                                                              (t 'doom-modeline-info)))
-                          (format "%s/%s/%s"
-                                  (doom-modeline-check-text (number-to-string .error)
-                                                              'doom-modeline-urgent)
-                                  (doom-modeline-check-text (number-to-string .warning)
-                                                              'doom-modeline-warning)
-                                  (doom-modeline-check-text (number-to-string .note)
-                                                              'doom-modeline-info)))))))))
+                                                              (t 'doom-modeline-info))))
+                          ('nil (format "%s/%s/%s"
+                                        (doom-modeline-check-text (number-to-string .error)
+                                                                  'doom-modeline-urgent)
+                                        (doom-modeline-check-text (number-to-string .warning)
+                                                                  'doom-modeline-warning)
+                                        (doom-modeline-check-text (number-to-string .note)
+                                                                  'doom-modeline-info)))
+                          ('icons (format "%s %s%s %s%s"
+                                          (doom-modeline-check-text (number-to-string .error)
+                                                                    'doom-modeline-urgent)
+                                          (doom-modeline-check-text doom-modeline-check-warning-icon
+                                                                    'doom-modeline-warning)
+                                          (doom-modeline-check-text (number-to-string .warning)
+                                                                    'doom-modeline-warning)
+                                          (doom-modeline-check-text doom-modeline-check-note-icon
+                                                                    'doom-modeline-info)
+                                          (doom-modeline-check-text (number-to-string .note)
+                                                                    'doom-modeline-info))))))))))
             (propertize
              text
              'help-echo (cond


### PR DESCRIPTION
This add an optional feature to include icons to check-simple-format, it makes doom-modeline fancy and easier to distinguish error types (related to: https://github.com/seagle0128/doom-modeline/issues/639), this implementation no needs to force users add-advices or make a custom (and more complex) segment to modeline.

I would like hear their suggest about this.