### PR TITLE
Unbreak compilation

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -109,30 +109,6 @@
 (defvar winum-auto-setup-mode-line)
 (defvar xah-fly-insert-state-p)
 
-(defcustom doom-modeline-check-error-icon
-  (doom-modeline-check-icon
-   "nf-md-alert_circle_outline" "❗" "!" 'doom-modeline-urgent)
-  "Icon to be using in check segment.
-Only works if `doom-modeline-check-simple-format' is set to icons."
-  :type '(string)
-  :group 'doom-modeline)
-
-(defcustom doom-modeline-check-warning-icon
-  (doom-modeline-check-icon
-   "nf-md-alert_outline" "⚠" "!" 'doom-modeline-warning)
-  "Icon to be using in check segment.
-Only works if `doom-modeline-check-simple-format' is set to icons."
-  :type '(string)
-  :group 'doom-modeline)
-
-(defcustom doom-modeline-check-note-icon
-  (doom-modeline-check-icon
-   "nf-md-information_outline" "❔" "i" 'doom-modeline-info)
-  "Icon to be using in check segment.
-Only works if `doom-modeline-check-simple-format' is set to icons."
-  :type '(string)
-  :group 'doom-modeline)
-
 (declare-function anzu--reset-status "ext:anzu")
 (declare-function anzu--where-is-here "ext:anzu")
 (declare-function async-inject-variables "ext:async")
@@ -778,6 +754,33 @@ Uses `nerd-icons-mdicon' to fetch the icon."
 (defun doom-modeline-check-text (text &optional face)
   "Displays the check TEXT with FACE."
   (propertize text 'face (or face 'mode-line)))
+
+(defcustom doom-modeline-check-error-icon
+  (doom-modeline-check-icon
+   "nf-md-alert_circle_outline" "❗" "!" 'doom-modeline-urgent)
+  "Icon to be using in check segment.
+Only works if `doom-modeline-check-simple-format' is set to the symbol
+`icons'."
+  :type '(string)
+  :group 'doom-modeline)
+
+(defcustom doom-modeline-check-warning-icon
+  (doom-modeline-check-icon
+   "nf-md-alert_outline" "⚠" "!" 'doom-modeline-warning)
+  "Icon to be using in check segment.
+Only works if `doom-modeline-check-simple-format' is set to the symbol
+`icons'."
+  :type '(string)
+  :group 'doom-modeline)
+
+(defcustom doom-modeline-check-note-icon
+  (doom-modeline-check-icon
+   "nf-md-information_outline" "❔" "i" 'doom-modeline-info)
+  "Icon to be using in check segment.
+Only works if `doom-modeline-check-simple-format' is set to the symbol
+`icons'."
+  :type '(string)
+  :group 'doom-modeline)
 
 ;; Flycheck
 


### PR DESCRIPTION
* doom-modeline-segments.el: Move the definition of custom variables doom-modeline-check-(error|warning|note)-icon after the defintion of the function `doom-modeline-check-text'.  This fixes the compilation error:
Symbol's function definition is void: doom-modeline-check-icon.