### PR TITLE
Add Kubernetes segment w/ kele.el

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The `doom-modeline` was designed for minimalism, and offers:
 - An indicator for current input method
 - An indicator for debug state
 - An indicator for remote host
+- An indicator for Kubernetes state with [`kele.el`](https://github.com/jinnovation/kele.el)
 - An indicator for LSP state with `lsp-mode` or `eglot`
 - An indicator for GitHub notifications
 - An indicator for unread emails with `mu4e-alert` and `gnus`

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -678,6 +678,11 @@ If nil, display only if the mode line is active."
   :type 'function
   :group 'doom-modeline)
 
+(defcustom doom-modeline-k8s-show-namespace t
+  "Whether to show the current Kubernetes context's default namespace."
+  :type 'boolean
+  :group 'doom-modeline)
+
 
 ;;
 ;; Faces

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -3174,8 +3174,8 @@ Otherwise, it displays the message like `message' would."
 
 (doom-modeline-def-segment k8s
   (when (and (bound-and-true-p kele-mode) (doom-modeline--active))
-    (let* ((ctx (kele-current-context-name))
-           (ns (kele-current-namespace))
+    (let* ((ctx (kele-current-context-name :wait nil))
+           (ns (kele-current-namespace :wait nil))
            (icon (doom-modeline-icon 'mdicon "nf-md-kubernetes" "K8s:" "K8s:"))
            (help-msg (let* ((msgs (list (format "Current context: %s" ctx))))
                        (when ns

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -3177,7 +3177,7 @@ Otherwise, it displays the message like `message' would."
     (let* ((ctx (kele-current-context-name :wait nil))
            (ns (kele-current-namespace :wait nil))
            (icon (doom-modeline-icon 'mdicon "nf-md-kubernetes" "K8s:" "K8s:"))
-           (help-msg (let* ((msgs (list (format "Current context: %s" ctx))))
+           (help-msg (let ((msgs (list (format "Current context: %s" ctx))))
                        (when ns
                          (setq msgs (append msgs (list (format "Current namespace: %s" ns)))))
                        (string-join msgs "\n"))))

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -195,6 +195,8 @@
 (declare-function image-get-display-property "image-mode")
 (declare-function jsonrpc--request-continuations "ext:jsonrpc" t t)
 (declare-function jsonrpc-last-error "ext:jsonrpc" t t)
+(declare-function kele-current-context-name "ext:kele")
+(declare-function kele-current-namespace "ext:kele")
 (declare-function lsp--workspace-print "ext:lsp-mode")
 (declare-function lsp-describe-session "ext:lsp-mode")
 (declare-function lsp-workspace-folders-open "ext:lsp-mode")
@@ -3165,6 +3167,27 @@ Otherwise, it displays the message like `message' would."
                   (apply #'format-message format-string args)))
           (force-mode-line-update)))
     (apply #'message format-string args)))
+
+;;
+;; Kubernetes
+;;
+
+(doom-modeline-def-segment k8s
+  (when (and (bound-and-true-p kele-mode) (doom-modeline--active))
+    (let* ((ctx (kele-current-context-name))
+           (ns (kele-current-namespace))
+           (icon (doom-modeline-icon 'mdicon "nf-md-kubernetes" "K8s:" "K8s:"))
+           (help-msg (let* ((msgs (list (format "Current context: %s" ctx))))
+                       (when ns
+                         (setq msgs (append msgs (list (format "Current namespace: %s" ns)))))
+                       (string-join msgs "\n"))))
+      (propertize (concat
+                   icon
+                   (doom-modeline-spc)
+                   ctx
+                   (when (and doom-modeline-k8s-show-namespace ns) (format "(%s)" ns))
+                   (doom-modeline-spc))
+                  'help-echo help-msg))))
 
 (provide 'doom-modeline-segments)
 

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -3187,6 +3187,10 @@ Otherwise, it displays the message like `message' would."
                    ctx
                    (when (and doom-modeline-k8s-show-namespace ns) (format "(%s)" ns))
                    (doom-modeline-spc))
+                  'local-map (let ((map (make-sparse-keymap)))
+                               (define-key map [mode-line down-mouse-1] kele-menu-map)
+                               map)
+                  'mouse-face 'doom-modeline-highlight
                   'help-echo help-msg))))
 
 (provide 'doom-modeline-segments)


### PR DESCRIPTION
This PR adds a segment for displaying the currently active Kubectl context and, optionally, the selected default namespace. It sources this information via [`kele.el`](https://github.com/jinnovation/kele.el), which handles config loading and refreshing.

<img width="370" alt="image" src="https://github.com/seagle0128/doom-modeline/assets/1932579/f57c1f47-1769-4c56-8937-497c5753d987">

We also hook up the menu map (introduced in jinnovation/kele.el#167 and jinnovation/kele.el#169) to allow users to perform basic Kubernetes management tasks via cursor, e.g. switching contexts/namespaces, starting/stopping proxy servers, etc.

<img width="759" alt="image" src="https://github.com/seagle0128/doom-modeline/assets/1932579/1c2a3d9e-4be2-4f65-9a66-25f3c7a7e24a">
