### PR TITLE
segments: k8s: hide when narrow screen

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -3173,7 +3173,7 @@ Otherwise, it displays the message like `message' would."
 ;;
 
 (doom-modeline-def-segment k8s
-  (when (and (bound-and-true-p kele-mode) (doom-modeline--active))
+  (when (and (bound-and-true-p kele-mode) (doom-modeline--segment-visible 'k8s))
     (let* ((ctx (kele-current-context-name :wait nil))
            (ns (kele-current-namespace :wait nil))
            (icon (doom-modeline-icon 'mdicon "nf-md-kubernetes" "K8s:" "K8s:"))


### PR DESCRIPTION
Uses `doom-modeline--segment-visible` to additionally hide the Kubernetes segment in narrow-modeline settings, unless user added it to `always-visible-segments`.