### PR TITLE
docs: checker -> check in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ Run `M-x customize-group RET doom-modeline RET` or set the variables.
      ;; Define your custom doom-modeline
      (doom-modeline-def-modeline 'my-simple-line
        '(bar matches buffer-info remote-host buffer-position parrot selection-info)
-       '(misc-info minor-modes input-method buffer-encoding major-mode process vcs checker))
+       '(misc-info minor-modes input-method buffer-encoding major-mode process vcs check))
 
      ;; Set default mode-line
      (add-hook 'doom-modeline-mode-hook


### PR DESCRIPTION
segment name "checker" was changed to "check" in https://github.com/seagle0128/doom-modeline/commit/62890effd01b7424728af8e39e0d9a09e05529a3, but the README still uses "checker" in an example.

This change broke my code to add padding on the right, taken from [here](https://github.com/doomemacs/doomemacs/issues/2967). The [doom emacs docs](https://docs.doomemacs.org/v21.12/modules/ui/modeline/#/troubleshooting/the-right-side-modeline-cut) also still use the wrong name. I'll see if I can also propose a fix over there.

**Edit** nevermind, it's already fixed in the doom-emacs github. The website just hasn't updated yet or something.