### PR TITLE
perf: calculate anzu count faster and with less memory

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -1113,10 +1113,11 @@ block selection."
 ;; mode-line.
 (defun doom-modeline-fix-anzu-count (positions here)
   "Calulate anzu count via POSITIONS and HERE."
-  (cl-loop for (start . end) in positions
-           collect t into before
+  (cl-loop with i = 0
+           for (start . end) in positions
+           do (cl-incf i)
            when (and (>= here start) (<= here end))
-           return (length before)
+           return i
            finally return 0))
 
 (advice-add #'anzu--where-is-here :override #'doom-modeline-fix-anzu-count)


### PR DESCRIPTION
Instead of allocating a list with N items and returning its length, just keep a tally of the number directly. This can also avoid generating lots of garbage that has to be collected.

The performance impact can be tested with this when using Evil:

```elisp
(benchmark-run 10 ; or some other number of repetitions
  (let ((last-kbd-macro [?/ ?. return])) ; initiate an evil search for the pattern "."
    (call-last-kbd-macro)))
```

On my machine in a 2.3 MB file, this went from 27.06 seconds (2.7 seconds per iteration) to 25.98 seconds (2.6 seconds per iteration), but before this change I also sometimes experience lockups where the search inexplicably takes several times longer.