### PR TITLE
Improve IRC buffer Stylize defcustom and enhance documentation

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -635,7 +635,7 @@ Groups' names list in `gnus-newsrc-alist'`"
 (defcustom doom-modeline-irc t
   "Whether display the irc notifications.
 
-It requires `circe' or `erc' package."
+It requires either `circe' , `erc' or `rcirc' package."
   :type 'boolean
   :group 'doom-modeline)
 

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -645,8 +645,21 @@ It requires `circe' or `erc' package."
   :group 'doom-modeline)
 
 (defcustom doom-modeline-irc-stylize #'doom-modeline-shorten-irc
-  "Function to stylize the irc buffer names."
-  :type 'function
+  "Which function to call to stylize IRC buffer names.
+
+Buffer names are stylized using the selected `function'.
+By default buffer names are shortened, you may want to disable or call
+your own function.
+The function must accept `buffer-name' and return `shortened-name'."
+  :type '(radio (function-item :tag "Shorten"
+                               :format "%t: %v\n %h"
+                               doom-modeline-shorten-irc)
+                (function-item
+                 :tag "Leave unchanged"
+                 :format "%t: %v\n"
+                 identity)
+                (function
+                 :tag "Other function"))
   :group 'doom-modeline)
 
 (defcustom doom-modeline-battery t

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -2583,12 +2583,16 @@ mouse-1: Toggle Debug on Quit"
 ;;
 
 (defun doom-modeline-shorten-irc (name)
-  "Wrapper for `tracking-shorten' and `erc-track-shorten-function' with NAME.
+  "Shorten IRC buffer `name' according to IRC mode.
 
-One key difference is that when `tracking-shorten' and
-`erc-track-shorten-function' returns nil we will instead return the original
-value of name. This is necessary in cases where the user has stylized the name
-to be an icon and we don't want to remove that so we just return the original."
+Calls the mode specific function to return the shortened
+version of `NAME' if applicable:
+- Circe: `tracking-shorten'
+- ERC: `erc-track-shorten-function'
+- rcirc: `rcirc-shorten-buffer-name'
+
+The specific function will decide how to stylize the buffer name,
+read the individual functions documentation for more."
   (or (and (fboundp 'tracking-shorten)
            (car (tracking-shorten (list name))))
       (and (boundp 'erc-track-shorten-function)


### PR DESCRIPTION
After #729 the option to not shorten IRC buffers. This PR documents the option and enhances the existing documentation
related to it.
Also mention rcirc as supported IRC mode for buffer segments.