### PR TITLE
Add the custom eglot mode line info after removing it

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -2163,10 +2163,10 @@ mouse-1: Toggle citre mode"
 
 (defun doom-modeline-override-eglot ()
   "Override `eglot' mode-line."
-  (if (and doom-modeline-lsp
-           (bound-and-true-p doom-modeline-mode))
-      (setq mode-line-misc-info
-            (delq (assq 'eglot--managed-mode mode-line-misc-info) mode-line-misc-info))
+  (when (and doom-modeline-lsp
+             (bound-and-true-p doom-modeline-mode))
+    (setq mode-line-misc-info
+          (delq (assq 'eglot--managed-mode mode-line-misc-info) mode-line-misc-info))
     (add-to-list 'mode-line-misc-info
                  `(eglot--managed-mode (" [" eglot--mode-line-format "] ")))))
 (add-hook 'eglot-managed-mode-hook #'doom-modeline-override-eglot)


### PR DESCRIPTION
This _feels_ like too obvious of a fix but I'm using eglot, doom-modeline, and have the LSP doom-modeline settings enabled, and I don't get any eglot information in the modeline unless I make this change. It implies that every eglot+doom-modeline user isn't seeing the feature work correctly, but I can't see how it _would_ be working without this change :sweat_smile: 

Anyway, this is a one-word change that modifies the eglot setup hook so that it will both 1) remove and then 2) add the mode-line-misc widget rather than 1) deleting the element from the list if `doom-modeline-lsp` is set OR 2) adding the element to the list if `doom-modeline-lsp` isn't set. 