### PR TITLE
Properly call `doom-modeline-vcs-display-function`

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -687,8 +687,8 @@ Uses `nerd-icons-octicon' to fetch the icon."
                               (doom-modeline-icon 'octicon "nf-oct-alert" "⚠" "!" :face 'doom-modeline-urgent))
                              (t (doom-modeline-vcs-icon "nf-dev-git_branch" "" "@" 'doom-modeline-info))))
                  (str (or (and vc-display-status
-                               (functionp #'doom-modeline-vcs-name)
-                               (funcall #'doom-modeline-vcs-name))
+                               (functionp doom-modeline-vcs-display-function)
+                               (funcall doom-modeline-vcs-display-function))
                           ""))
                  (face (cond ((eq state 'needs-update)
                               '(doom-modeline-warning bold))


### PR DESCRIPTION
This PR does exactly what the title says. This feature was added in [this commit](https://github.com/seagle0128/doom-modeline/commit/ef8038140fc76d96614fc8dd34a8c85cd4843b0c) but the author directly called the default function instead of calling the function stored in the custom variable.