### PR TITLE
feat: Show file modification status outside Emacs.

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -298,7 +298,12 @@ Uses `nerd-icons-mdicon' to fetch the icon."
         (when doom-modeline-buffer-state-icon
           (ignore-errors
             (concat
-             (cond (buffer-read-only
+             (cond ((not (or (and (buffer-file-name) (file-remote-p buffer-file-name))
+                             (verify-visited-file-modtime (current-buffer))))
+                    (doom-modeline-buffer-file-state-icon
+                     "nf-md-reload_alert" "⟳" "%1*"
+                     'doom-modeline-warning))
+                   (buffer-read-only
                     (doom-modeline-buffer-file-state-icon
                      "nf-md-lock" "🔒" "%1*"
                      'doom-modeline-warning))


### PR DESCRIPTION
When the file associated with the current buffer is modified outside Emacs, a new icon is used to indicate that the buffer needs to be reverted.  This feature is from smart-mode-line.