### PR TITLE
Add option to override face attributes for spaces used in padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,13 @@ Run `M-x customize-group RET doom-modeline RET` or set the variables.
 ;; displayed. It can be an integer or a float number. `nil' means no limit."
 (setq doom-modeline-window-width-limit 85)
 
+;; Override attributes of the face used for padding.
+;; If the space character is very thin in the modeline, for example if a
+;; variable pitch font is used there, then segments may appear unusually close.
+;; To use the space character from the `fixed-pitch' font family instead, set
+;; this variable to `(list :family (face-attribute 'fixed-pitch :family))'.
+(setq doom-modeline-spc-face-overrides nil)
+
 ;; How to detect the project root.
 ;; nil means to use `default-directory'.
 ;; The project management packages have some issues on detecting project root.

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -123,6 +123,16 @@ displayed. It can be an integer or a float number. nil means no limit."
                  (const :tag "Disable" nil))
   :group 'doom-modeline)
 
+(defcustom doom-modeline-spc-face-overrides nil
+  "Property list of face attributes for whitespace in the modeline.
+
+These face attributes override any attributes for spacing produced by
+`doom-modeline-spc', `doom-modeline-wspc', and `doom-modeline-vspc'.
+
+See `defface' for possible attributes and values in this property list."
+  :type 'plist
+  :group 'doom-modeline)
+
 (defcustom doom-modeline-project-detection 'auto
   "How to detect the project root.
 
@@ -1342,16 +1352,16 @@ If DEFAULT is non-nil, set the default mode-line for all buffers."
 
 (defsubst doom-modeline-spc ()
   "Whitespace."
-  (propertize " " 'face (doom-modeline-face)))
+  (propertize " " 'face (doom-modeline-spc-face)))
 
 (defsubst doom-modeline-wspc ()
   "Wide Whitespace."
-  (propertize "  " 'face (doom-modeline-face)))
+  (propertize "  " 'face (doom-modeline-spc-face)))
 
 (defsubst doom-modeline-vspc ()
   "Thin whitespace."
   (propertize " "
-              'face (doom-modeline-face)
+              'face (doom-modeline-spc-face)
               'display '((space :relative-width 0.5))))
 
 (defun doom-modeline-face (&optional face inactive-face)
@@ -1364,6 +1374,12 @@ If INACTIVE-FACE is nil, `mode-line-inactive' face will be used."
           '(:inherit (doom-modeline mode-line)))
     (or (and (facep inactive-face) `(:inherit (doom-modeline ,inactive-face)))
         '(:inherit (doom-modeline mode-line-inactive)))))
+
+(defun doom-modeline-spc-face ()
+  "Apply `doom-modeline-spc-face-overrides' to `doom-modeline-face'."
+  (append
+   '(:inherit (doom-modeline-face))
+   doom-modeline-spc-face-overrides))
 
 (defun doom-modeline-string-pixel-width (str)
   "Return the width of STR in pixels."


### PR DESCRIPTION
When using a variable pitch font in the modeline, the space characters used as padding between segments can be too thin. This new option enables users to override face attributes just for the space characters used as padding in the modeline, such as their font family or height.