### PR TITLE
Issue 765: Add uv python version to bootstrap

### DIFF
--- a/doom-modeline-env.el
+++ b/doom-modeline-env.el
@@ -221,6 +221,7 @@ PARSER should be a function for parsing COMMAND's output line-by-line, to
                                            (or doom-modeline-env-python-executable
                                                python-shell-interpreter
                                                "python"))))
+                       ((executable-find "uv") (list "uv" "run" "python" "--version"))
                        ((list (or doom-modeline-env-python-executable
                                   python-shell-interpreter
                                   "python")


### PR DESCRIPTION
Addresses https://github.com/seagle0128/doom-modeline/issues/765

Below are two examples of projects using different Python versions displayed in the same Emacs session (just switched project).

Project using Python 3.13.x:
![image](https://github.com/user-attachments/assets/f7c95102-d4a1-46f5-a3dc-01e838bac4f5)

Project using Python 3.12.x:
![image](https://github.com/user-attachments/assets/65e03e51-6738-415a-9e77-cedeb50ce667)

