### PR TITLE
fix: don't sync `uv.lock` when detecting Python version

### DIFF
--- a/doom-modeline-env.el
+++ b/doom-modeline-env.el
@@ -221,7 +221,7 @@ PARSER should be a function for parsing COMMAND's output line-by-line, to
                                            (or doom-modeline-env-python-executable
                                                python-shell-interpreter
                                                "python"))))
-                       ((executable-find "uv") (list "uv" "run" "python" "--version"))
+                       ((executable-find "uv") (list "uv" "run" "--no-sync" "python" "--version"))
                        ((list (or doom-modeline-env-python-executable
                                   python-shell-interpreter
                                   "python")


### PR DESCRIPTION
I found after 1ce87bea1fcf045d1d2cb52e8e7e2bed7d89bf3a (#766) that `uv.lock` files were spontaneously appearing in my projects. This is because I have `uv` installed and `executable-find` was resolving the binary and running
```
uv run python --version
```
which automatically will materialize a `uv.lock` file (if it's not not present; see the `uv run` [reference](https://docs.astral.sh/uv/reference/cli/#uv-run)). For just detecting the Python version I think this should be avoided; this PR adds the `--no-sync` option to `uv run`; from the CLI docs:

```
--no-sync                                Avoid syncing the virtual environment [env: UV_NO_SYNC=]
```