### PR TITLE
perf: Cache font height calculation in modeline

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -1388,14 +1388,34 @@ If INACTIVE-FACE is nil, `mode-line-inactive' face will be used."
     (* (string-width str) (window-font-width nil 'mode-line)
        (if (display-graphic-p) 1.05 1.0))))
 
+;; Per-frame cache for mode-line font height.
+(defvar doom-modeline--font-height-cache (make-hash-table :test 'eq :weakness 'key)
+  "Per-frame cache for mode-line font height.
+Keys are frame objects, values are cons cells (CACHED-HEIGHT . CACHED-FACE-HEIGHT-ATTR).")
+
+(defun doom-modeline--reset-font-height-cache (&rest _)
+  "Reset cached font height for all frames."
+  (clrhash doom-modeline--font-height-cache))
+
 (defun doom-modeline--font-height ()
-  "Calculate the actual char height of the mode-line."
-  (let ((height (face-attribute 'mode-line :height))
-        (char-height (window-font-height nil 'mode-line)))
-    (round
-     (* 1.0 (cond ((integerp height) (/ height 10))
-                  ((floatp height) (* height char-height))
-                  (t char-height))))))
+  "Calculate the actual char height of the mode-line for the current frame.
+The result is cached per-frame to avoid expensive calculations during redisplay."
+  (let* ((frame (selected-frame))
+         (current-face-height-attr (face-attribute 'mode-line :height frame)) ; Get attribute for the specific frame
+         (cache-entry (gethash frame doom-modeline--font-height-cache)))
+    (if (and cache-entry
+             (equal (cdr cache-entry) current-face-height-attr))
+        ;; Return cached value if frame exists in cache and face attribute matches
+        (car cache-entry)
+      ;; Else, recalculate and update cache for this frame
+      (let* ((base-char-height (window-font-height nil 'mode-line)) ; Use window-font-height in the context of the frame/window
+             (new-height (round
+                          (* 1.0 (cond ((integerp current-face-height-attr) (/ current-face-height-attr 10.0)) ; Ensure float division
+                                       ((floatp current-face-height-attr) (* current-face-height-attr base-char-height))
+                                       (t base-char-height))))))
+        ;; Update cache for the current frame
+        (puthash frame (cons new-height current-face-height-attr) doom-modeline--font-height-cache)
+        new-height))))
 
 (defun doom-modeline--original-value (sym)
   "Return the original value for SYM, if any.

--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -232,6 +232,9 @@ If DEFAULT is non-nil, set the default mode-line for all buffers."
         ;; Automatically set mode-lines
         (add-hook 'after-change-major-mode-hook #'doom-modeline-auto-set-modeline)
 
+        ;; Setup font height cache hook
+        (add-hook 'after-setting-font-hook #'doom-modeline--reset-font-height-cache)
+        
         ;; Special handles
         (advice-add #'helm-display-mode-line :after #'doom-modeline-set-helm-modeline)
         (setq helm-ag-show-status-function #'doom-modeline-set-helm-modeline))
@@ -251,6 +254,9 @@ If DEFAULT is non-nil, set the default mode-line for all buffers."
 
       ;; For two-column editing
       (setq 2C-mode-line-format (doom-modeline--original-value '2C-mode-line-format))
+
+      ;; Remove font height cache hook
+      (remove-hook 'after-setting-font-hook #'doom-modeline--reset-font-height-cache)
 
       ;; Cleanup
       (remove-hook 'after-change-major-mode-hook #'doom-modeline-auto-set-modeline)


### PR DESCRIPTION
Hi. I have noticed in #768 that the font height calculations take up a significant portion of Doom Modeline's CPU/Memory usage. To alleviate this, I have introduced in this PR a cache for the modeline font height.