### PR TITLE
Fix direnv python version

### DIFF
--- a/doom-modeline-env.el
+++ b/doom-modeline-env.el
@@ -217,7 +217,7 @@ PARSER should be a function for parsing COMMAND's output line-by-line, to
                                    ;; Direnv unfortunately writes crao on stderr
                                    ;; so we need to pipe that to /dev/null
                                    (format "direnv exec %s %s --version 2>/dev/null"
-                                           default-directory
+                                           (file-truename default-directory)
                                            (or doom-modeline-env-python-executable
                                                python-shell-interpreter
                                                "python"))))


### PR DESCRIPTION

```sh
/tmp/demo/python3 via 🐍 v3.12.9
❯ uname -msr
Darwin 24.3.0 arm64
/tmp/demo/python3 via 🐍 v3.12.9
❯ pwd
/tmp/demo/python3
/tmp/demo/python3 via 🐍 v3.12.9
❯ ll /tmp
lrwxr-xr-x 1 root wheel 11 2025-03-06 18:06 /tmp -> private/tmp
/tmp/demo/python3 via 🐍 v3.12.9
❯ direnv allow .
direnv: loading /private/tmp/demo/python3/.envrc
direnv: export +UV_ACTIVE +VIRTUAL_ENV ~PATH
/tmp/demo/python3 via 🐍 v3.10.16 (python3)
❯ cat ~/.local/share/direnv/allow/e7b1304f1238be3923c42c122b704e033f5b09dfb946c5e8bac837b10f692247
/private/tmp/demo/python3/.envrc
/tmp/demo/python3 via 🐍 v3.10.16 (python3)
❯ direnv exec /tmp/demo/python3 python --version
direnv: error /tmp/demo/python3/.envrc is blocked. Run `direnv allow` to approve its content
/tmp/demo/python3 via 🐍 v3.10.16 (python3)
❯ direnv exec /private/tmp/demo/python3 python --version 2>/dev/null
Python 3.10.16
```

direnv used true file name in its allow directory, `direnv exec default-directory` will fail in symbolic links. 


Use file-truename for direnv exec directory to avoid potential blocking issues caused by symbolic links.
