### PR TITLE
Add customizable alist to map VCS states to faces

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,15 @@ Run `M-x customize-group RET doom-modeline RET` or set the variables.
 ;; The function to display the branch name.
 (setq doom-modeline-vcs-display-function #'doom-modeline-vcs-name)
 
+;; Alist mapping VCS states to their corresponding faces.
+;; See `vc-state' for possible values of the state.
+;; For states not explicitly listed, the `doom-modeline-vcs-default' face is used.
+(setq doom-modeline-vcs-state-faces-alist
+      '((needs-update . (doom-modeline-warning bold))
+        (removed . (doom-modeline-urgent bold))
+        (conflict . (doom-modeline-urgent bold))
+        (unregistered . (doom-modeline-urgent bold))))
+
 ;; Whether display the icon of check segment. It respects option `doom-modeline-icon'.
 (setq doom-modeline-check-icon t)
 

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -497,6 +497,20 @@ It respects option `doom-modeline-icon'."
   :type 'function
   :group 'doom-modeline)
 
+(defcustom doom-modeline-vcs-state-faces-alist
+  '((needs-update . (doom-modeline-warning bold))
+    (removed . (doom-modeline-urgent bold))
+    (conflict . (doom-modeline-urgent bold))
+    (unregistered . (doom-modeline-urgent bold)))
+  "Alist mapping VCS states to their corresponding faces.
+
+See `vc-state' for possible values of the state.
+
+For states not explicitly listed, the `doom-modeline-vcs-default' face
+is used."
+  :type '(alist :key-type symbol :value-type sexp)
+  :group 'doom-modeline)
+
 (defcustom doom-modeline-check-icon t
   "Whether display the icon of check segment.
 
@@ -992,6 +1006,11 @@ Also see the face `doom-modeline-unread-number'."
 (defface doom-modeline-repl-warning
   '((t (:inherit doom-modeline-warning)))
   "Face for REPL warning state."
+  :group 'doom-modeline-faces)
+
+(defface doom-modeline-vcs-default
+  '((t (:inherit (doom-modeline-info bold))))
+  "Default face for VCS states not explicitly listed in `doom-modeline-vcs-state-faces-alist'."
   :group 'doom-modeline-faces)
 
 (defface doom-modeline-lsp-success

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -700,11 +700,8 @@ Uses `nerd-icons-octicon' to fetch the icon."
                                (functionp doom-modeline-vcs-display-function)
                                (funcall doom-modeline-vcs-display-function))
                           ""))
-                 (face (cond ((eq state 'needs-update)
-                              '(doom-modeline-warning bold))
-                             ((memq state '(removed conflict unregistered))
-                              '(doom-modeline-urgent bold))
-                             (t '(doom-modeline-info bold))))
+                 (face (or (cdr (assq state doom-modeline-vcs-state-faces-alist))
+                           'doom-modeline-vcs-default))
                  (text (propertize (if (length> str doom-modeline-vcs-max-length)
                                        (concat
                                         (substring str 0 (- doom-modeline-vcs-max-length 3))


### PR DESCRIPTION
Add a new customizable variable `doom-modeline-vcs-state-faces-alist`
that allows users to define faces for different version control states.
This replaces hardcoded face mapping in the VCS segment with a more
flexible configuration option.

Also add a default face `doom-modeline-vcs-default` that's used for any
state not explicitly defined in the alist.