### PR TITLE
Add the ability to configure whether the remote host should be shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,9 @@ Run `M-x customize-group RET doom-modeline RET` or set the variables.
 ;; If nil, display only if the mode line is active.
 (setq doom-modeline-display-misc-in-all-mode-lines t)
 
+;; Whether to display the remote host information.
+(setq doom-modeline-remote-host t)
+
 ;; The function to handle `buffer-file-name'.
 (setq doom-modeline-buffer-file-name-function #'identity)
 

--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -374,6 +374,11 @@ It respects `doom-modeline-enable-word-count'."
   :type 'boolean
   :group 'doom-modeline)
 
+(defcustom doom-modeline-remote-host t
+  "Whether to display remote host information."
+  :type 'boolean
+  :group 'doom-modeline)
+
 ;; It is based upon `editorconfig-indentation-alist' but is used to read indentation levels instead
 ;; of setting them. (https://github.com/editorconfig/editorconfig-emacs)
 (defcustom doom-modeline-indent-alist

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -578,7 +578,7 @@ project directory is important."
 
 (doom-modeline-def-segment remote-host
   "Hostname for remote buffers."
-  (when default-directory
+  (when (and doom-modeline-remote-host default-directory)
     (when-let* ((host (file-remote-p default-directory 'host)))
       (propertize
        (concat "@" host)


### PR DESCRIPTION
Adding this as on my machine, ssh address of the remote hosts I'm connecting to is slow long that they're hiding information from the rest of the modeline.

Tested this locally with both `nil` and `t` values of the variable.  

Thanks!