### PR TITLE
feat: add emacs-reader document position

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -103,6 +103,8 @@
 (defvar phi-search--selection)
 (defvar phi-search-mode-line-format)
 (defvar projectile-mode-map)
+(defvar reader-current-doc-pagenumber)
+(defvar reader-current-doc-pagecount)
 (defvar rcirc-activity)
 (defvar symbol-overlay-keywords-alist)
 (defvar symbol-overlay-temp-symbol)
@@ -2556,6 +2558,25 @@ mouse-1: Toggle Debug on Quit"
   "Display PDF pages."
   doom-modeline--pdf-pages)
 
+
+;;
+;; Reader Pages
+;;
+
+(defvar-local doom-modeline--reader-pages nil)
+(defun doom-modeline-update-reader-pages ()
+  "Update Emacs Reader document pages."
+  (setq doom-modeline--reader-pages
+        (format "  P%d/P%d "
+                (or (eval `(reader-current-doc-pagenumber)) 0)
+                (or reader-current-doc-pagecount 0))))
+
+(advice-add 'reader-dyn--next-page :after #'doom-modeline-update-reader-pages)
+(advice-add 'reader-dyn--prev-page :after #'doom-modeline-update-reader-pages)
+
+(doom-modeline-def-segment reader-pages
+  "Display Emacs Reader document pages."
+  doom-modeline--reader-pages)
 
 ;;
 ;; `mu4e' notifications

--- a/doom-modeline.el
+++ b/doom-modeline.el
@@ -128,7 +128,7 @@
   '(compilation objed-state misc-info battery debug minor-modes input-method indent-info buffer-encoding major-mode time))
 
 (doom-modeline-def-modeline 'pdf
-  '(bar window-number modals matches buffer-info pdf-pages)
+  '(bar window-number modals matches buffer-info pdf-pages reader-pages)
   '(compilation misc-info major-mode process vcs time))
 
 (doom-modeline-def-modeline 'org-src
@@ -186,6 +186,8 @@ If DEFAULT is non-nil, set the default mode-line for all buffers."
     (image-mode           . media)
     (pdf-view-mode        . pdf)
     (org-src-mode         . org-src)
+    (pdf-view-mode        . pdf)
+    (reader-mode          . pdf)
     (paradox-menu-mode    . package)
     (xwidget-webkit-mode  . minimal)
     (git-timemachine-mode . timemachine)


### PR DESCRIPTION
as title mentions. Also placed under `pdf` since there is no `document` option. (supports other document types)