### PR TITLE
Pacify Emacs 31 compiler warning

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -688,8 +688,8 @@ Uses `nerd-icons-octicon' to fetch the icon."
 
 (defun doom-modeline--in-git-worktree-p ()
   "Return non-nil if the current buffer's file is in a git worktree."
-  (when-let ((git-dir (and buffer-file-name
-                           (locate-dominating-file buffer-file-name ".git"))))
+  (when-let* ((git-dir (and buffer-file-name
+                            (locate-dominating-file buffer-file-name ".git"))))
     ;; In a worktree, .git is a file (not a directory)
     (file-regular-p (expand-file-name ".git" git-dir))))
 


### PR DESCRIPTION
* doom-modeline-segments.el (doom-modeline--in-git-worktree-p): Use `when-let*' instead of `when-let' in order to pacify the compiler.