### PR TITLE
fix: set battery-mode-line-string value when updating battery status

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -3038,6 +3038,11 @@ Uses `nerd-icons-mdicon' to fetch the icon."
             (run-hook-with-args 'battery-update-functions data)
             (cons (propertize icon 'help-echo help-echo)
                   (propertize text 'face face 'help-echo help-echo)))))
+  (setq battery-mode-line-string (substring
+                                  (concat
+                                   (substring-no-properties (car doom-modeline--battery-status))
+                                   (substring-no-properties (cdr doom-modeline--battery-status)))
+                                  0 -1))
   (force-mode-line-update t))
 
 (doom-modeline-add-variable-watcher


### PR DESCRIPTION
Hello.

This change is tangentially related to #792. Recently, I noticed that `battery-mode-line-string` was not being updated on the tab-bar, so I checked `doom-modeline-update-battery-status` and I saw that it doesn't set any value for `battery-mode-line-string`. This commit fixes that.
With the following code, you'll notice that the time will appear on the tab-bar, and with this commit, so will the battery percentage:
```
(display-time-mode +1)
(display-battery-mode +1)
(tab-bar-mode +1)
(add-to-list 'tab-bar-format 'tab-bar-format-align-right 'append)
(add-to-list 'tab-bar-format 'doom-modeline-tab-bar-format-global 'append)
```