### PR TITLE
fix: check if battery-mode-line-string battery icon can be displayed

### DIFF
--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -3042,7 +3042,12 @@ Uses `nerd-icons-mdicon' to fetch the icon."
   (when doom-modeline--battery-status
     (setq battery-mode-line-string (substring
                                     (concat
-                                     (substring-no-properties (car doom-modeline--battery-status))
+                                     (let* ((status (car doom-modeline--battery-status))
+                                            (substr (substring-no-properties status))
+                                            (char   (string-to-char substr)))
+                                       (unless (or (eq (char-displayable-p char) 'unicode)
+                                                   (null (char-displayable-p char)))
+                                         substr))
                                      (substring-no-properties (cdr doom-modeline--battery-status)))
                                     0 -1)))
   (force-mode-line-update t))


### PR DESCRIPTION
This fix specifically checks whether the user's font can display the battery icon. If not, then it skips the icon.