### PR TITLE
Pacify compiler warnings

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -723,9 +723,9 @@ It requires either `circe' , `erc' or `rcirc' package."
 
 (defcustom doom-modeline-irc-priority-only nil
   "Only show IRC notifications for buffers matching a filter.
-This lets you filter out general channel activity and only show what matters to you.
-Requires `circe' and `tracking-faces-priorities' or `rcirc' and `rcirc-keywords'
-to be configured."
+This lets you filter out general channel activity and only show what
+matters to you.  Requires `circe' and `tracking-faces-priorities' or
+`rcirc' and `rcirc-keywords' to be configured."
   :type 'boolean
   :group 'doom-modeline)
 

--- a/doom-modeline-segments.el
+++ b/doom-modeline-segments.el
@@ -107,10 +107,12 @@
 (defvar reader-current-doc-pagenumber)
 (defvar reader-current-doc-pagecount)
 (defvar rcirc-activity)
+(defvar rcirc-activity-types)
 (defvar symbol-overlay-keywords-alist)
 (defvar symbol-overlay-temp-symbol)
 (defvar text-scale-mode-amount)
 (defvar tracking-buffers)
+(defvar tracking-faces-priorities)
 (defvar visual-replace--calling-buffer)
 (defvar visual-replace--match-ovs)
 (defvar winum-auto-setup-mode-line)
@@ -2840,7 +2842,8 @@ read the individual functions documentation for more."
   (bound-and-true-p rcirc-track-minor-mode))
 
 (defun doom-modeline--circe-mention-buffers ()
-  "Return filtered 'circe' buffers based on variable 'tracking-faces-priorities'."
+  "Return filtered `circe' buffers.
+The return value is based on the variable `tracking-faces-priorities'."
   (if doom-modeline-irc-priority-only
       (seq-filter
        (lambda (buf)
@@ -2850,7 +2853,7 @@ read the individual functions documentation for more."
     tracking-buffers))
 
 (defun doom-modeline--rcirc-mention-buffers ()
-  "Return filtered 'rcirc' buffers based on variable 'rcirc-keywords'."
+  "Return filtered `rcirc' buffers based on variable `rcirc-keywords'."
   (if doom-modeline-irc-priority-only
       (seq-filter
        (lambda (buf)


### PR DESCRIPTION
* doom-modeline-core.el (doom-modeline-irc-priority-only): Fill docstring in order to avoid "docstring wider than 80 characters" warning.

* doom-modeline-segments.el (rcirc-activity-types) (tracking-faces-priorities): defvar the variables. (doom-modeline--circe-mention-buffers)
(doom-modeline--rcirc-mention-buffers): Fix quotes, re-fill docstring.