### PR TITLE
fix: Preserve multiple face properties in inactive mode-line text.

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -1640,8 +1640,8 @@ ARGS is same as `nerd-icons-octicon' and others."
   (let ((text (string-replace "%" "%%" text)))
     (if (doom-modeline--active)
         text
-      (propertize text 'face `(:inherit (mode-line-inactive
-                                         ,(get-text-property 0 'face text)))))))
+      (add-face-text-property 0 (length text) 'mode-line-inactive nil text)
+      text)))
 
 (defun doom-modeline-vcs-name ()
   "Display the vcs name."


### PR DESCRIPTION
When `doom-modeline-display-text` processes text with multiple distinct face regions, the original implementation loses face properties for all regions except the first. Use `add-face-text-property` instead, which ensures personalized styles for different regions are correctly displayed.